### PR TITLE
Pause timer when navigating and allow daily plan adjustments

### DIFF
--- a/stores/useTimerStore.ts
+++ b/stores/useTimerStore.ts
@@ -193,15 +193,14 @@ export const useTimerStore = create<TimerStore>((set, get) => ({
 
   restoreState: () => {
     const savedState = storage.getTimerState();
-    if (savedState && savedState.sessionStart) {
-      const now = Date.now();
-      const sessionStart = new Date(savedState.sessionStart).getTime();
-      const timePassed = Math.floor((now - sessionStart) / 1000);
-      const adjustedTimeRemaining = Math.max(0, savedState.timeRemaining - timePassed);
-
+    if (savedState) {
       set({
         ...savedState,
-        timeRemaining: adjustedTimeRemaining,
+        // Reset session start to now so elapsed time while away isn't counted
+        sessionStart:
+          savedState.isRunning && !savedState.isPaused
+            ? new Date().toISOString()
+            : savedState.sessionStart,
       });
     }
   },


### PR DESCRIPTION
## Summary
- avoid decreasing timer while away by resetting session start on restore
- enable replanning daily blocks with add/remove project UI

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68becaa5bbb4832ba9ac649dc8495da0