### PR TITLE
feat(timer): retain remaining time when switching tasks

### DIFF
--- a/components/focus/FocusDialog.tsx
+++ b/components/focus/FocusDialog.tsx
@@ -18,7 +18,7 @@ interface FocusDialogProps {
 
 export function FocusDialog({ open, onOpenChange }: FocusDialogProps) {
   const { projects, tasks } = useAppStore();
-  const { startTimer } = useTimerStore();
+  const { startTimer, switchTask, isRunning } = useTimerStore();
 
   const [selectedProjectId, setSelectedProjectId] = useState<string>('');
   const [selectedTaskId, setSelectedTaskId] = useState<string>('');
@@ -33,7 +33,11 @@ export function FocusDialog({ open, onOpenChange }: FocusDialogProps) {
   const handleStart = () => {
     if (!selectedProjectId) return;
     const taskId = selectedTaskId && selectedTaskId !== 'none' ? selectedTaskId : undefined;
-    startTimer(timerType, selectedProjectId, taskId);
+    if (isRunning) {
+      switchTask(selectedProjectId, taskId);
+    } else {
+      startTimer(timerType, selectedProjectId, taskId);
+    }
     onOpenChange(false);
 
     // Reset selections

--- a/components/tasks/TaskCard.tsx
+++ b/components/tasks/TaskCard.tsx
@@ -19,7 +19,7 @@ interface TaskCardProps {
 
 export function TaskCard({ task, onEdit }: TaskCardProps) {
   const { projects, updateTask, deleteTask } = useAppStore();
-  const { startTimer } = useTimerStore();
+  const { startTimer, switchTask, isRunning } = useTimerStore();
   const router = useRouter();
 
   const project = projects.find(p => p.id === task.projectId);
@@ -110,7 +110,11 @@ export function TaskCard({ task, onEdit }: TaskCardProps) {
           className="text-blue-400 hover:text-blue-300"
           onClick={() => {
             if (!project) return;
-            startTimer('pomodoro', project.id, task.id);
+            if (isRunning) {
+              switchTask(project.id, task.id);
+            } else {
+              startTimer('pomodoro', project.id, task.id);
+            }
             router.push('/focus');
           }}
         >

--- a/types/index.ts
+++ b/types/index.ts
@@ -59,4 +59,5 @@ export interface TimerState {
   selectedProjectId?: string;
   selectedTaskId?: string;
   sessionStart?: string;
+  elapsedInCycle: number;
 }


### PR DESCRIPTION
## Summary
- track elapsed time within the current cycle
- add `switchTask` to log current focus and continue with remaining minutes
- switch TaskCard and FocusDialog to reuse running timer instead of restarting

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c013fbdbac832b9ae0d7adeb6d7849