### PR TITLE
Enhance PDF export, settings persistence, and calendar view

### DIFF
--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { z } from 'zod';
+export const dynamic = 'force-dynamic';
+
+const defaultSettings = {
+  workMin: 50,
+  shortBreakMin: 10,
+  longBreakMin: 20,
+  cyclesToLongBreak: 3,
+  autoStartNext: true,
+  soundOn: true,
+};
+
+export async function GET() {
+  const existing = await prisma.pomodoroSettings.findFirst();
+  if (existing) return NextResponse.json(existing);
+  const created = await prisma.pomodoroSettings.create({ data: defaultSettings });
+  return NextResponse.json(created);
+}
+
+export async function PATCH(req: Request) {
+  try {
+    const body = await req.json();
+    const schema = z.object({
+      workMin: z.number().int(),
+      shortBreakMin: z.number().int(),
+      longBreakMin: z.number().int(),
+      cyclesToLongBreak: z.number().int(),
+      autoStartNext: z.boolean(),
+      soundOn: z.boolean(),
+    });
+    const parsed = schema.parse(body);
+    const existing = await prisma.pomodoroSettings.findFirst();
+    const updated = existing
+      ? await prisma.pomodoroSettings.update({ where: { id: existing.id }, data: parsed })
+      : await prisma.pomodoroSettings.create({ data: parsed });
+    return NextResponse.json(updated);
+  } catch (err: any) {
+    return NextResponse.json({ message: err.message ?? 'Erro ao atualizar' }, { status: 400 });
+  }
+}

--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useState } from 'react';
+import { useAppStore } from '@/stores/useAppStore';
+import { DayPicker } from 'react-day-picker';
+import { Card } from '@/components/ui/card';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { format, startOfWeek, addDays, isSameDay } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+
+export default function CalendarPage() {
+  const { sessions } = useAppStore();
+  const [view, setView] = useState<'month' | 'week' | 'day'>('month');
+  const [selectedDate, setSelectedDate] = useState<Date>(new Date());
+
+  const sessionsForDate = sessions.filter(s => isSameDay(new Date(s.start), selectedDate));
+
+  const weekStart = startOfWeek(selectedDate, { weekStartsOn: 1 });
+  const weekDays = Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));
+
+  return (
+    <div className="p-6 max-w-5xl mx-auto">
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-3xl font-bold text-white">Calendário</h1>
+        <Select value={view} onValueChange={v => setView(v as any)}>
+          <SelectTrigger className="w-32 bg-gray-900/50 border-gray-700 text-white">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent className="bg-gray-800 border-gray-700">
+            <SelectItem value="month">Mês</SelectItem>
+            <SelectItem value="week">Semana</SelectItem>
+            <SelectItem value="day">Dia</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {view === 'month' && (
+        <Card className="p-4 bg-gray-900/50 border-gray-800">
+          <DayPicker
+            mode="single"
+            locale={ptBR}
+            selected={selectedDate}
+            onSelect={setSelectedDate}
+            modifiers={{
+              hasSessions: sessions.map(s => new Date(s.start)),
+            }}
+            modifiersClassNames={{
+              hasSessions: 'bg-blue-600 text-white rounded-full',
+            }}
+          />
+        </Card>
+      )}
+
+      {view === 'week' && (
+        <Card className="p-4 bg-gray-900/50 border-gray-800">
+          <div className="grid grid-cols-7 gap-2 text-center text-white">
+            {weekDays.map(day => {
+              const daySessions = sessions.filter(s => isSameDay(new Date(s.start), day));
+              const total = daySessions.reduce((sum, s) => sum + s.durationSec, 0) / 3600;
+              return (
+                <div key={day.toISOString()}>
+                  <div className="font-medium">{format(day, 'dd/MM')}</div>
+                  <div className="text-sm text-gray-400">{total.toFixed(1)}h</div>
+                </div>
+              );
+            })}
+          </div>
+        </Card>
+      )}
+
+      {view === 'day' && (
+        <Card className="p-4 bg-gray-900/50 border-gray-800">
+          <h2 className="text-white mb-4">{format(selectedDate, 'PPPP', { locale: ptBR })}</h2>
+          {sessionsForDate.length > 0 ? (
+            <ul className="space-y-2">
+              {sessionsForDate.map(s => (
+                <li key={s.id} className="text-gray-300">
+                  {format(new Date(s.start), 'HH:mm')} - {s.end ? format(new Date(s.end), 'HH:mm') : '-'} ({(s.durationSec / 3600).toFixed(2)}h)
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <div className="text-gray-500">Sem sessões</div>
+          )}
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/app/reports/page.tsx
+++ b/app/reports/page.tsx
@@ -12,12 +12,14 @@ import { format, startOfDay, endOfDay } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import { Download, Filter, BarChart, FileDown } from 'lucide-react';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, PieChart, Pie, Cell } from 'recharts';
+import { ManualSessionDialog } from '@/components/sessions/ManualSessionDialog';
 
 export default function ReportsPage() {
   const { sessions, projects, tasks } = useAppStore();
   const [startDate, setStartDate] = useState(format(new Date(Date.now() - 7 * 24 * 60 * 60 * 1000), 'yyyy-MM-dd'));
   const [endDate, setEndDate] = useState(format(new Date(), 'yyyy-MM-dd'));
   const [selectedProjectId, setSelectedProjectId] = useState<string>('all');
+  const [manualOpen, setManualOpen] = useState(false);
 
   // Filter sessions by date range and project
   const filteredSessions = sessions.filter(session => {
@@ -104,14 +106,12 @@ export default function ReportsPage() {
   const handleExportPdf = () => {
     const exportData = filteredSessions.map(session => {
       const project = projects.find(p => p.id === session.projectId);
-      const task = session.taskId ? tasks.find(t => t.id === session.taskId) : null;
 
       return {
         'Data': format(new Date(session.start), 'dd/MM/yyyy'),
         'Início': format(new Date(session.start), 'HH:mm'),
         'Fim': session.end ? format(new Date(session.end), 'HH:mm') : 'Em andamento',
         'Projeto': project?.name || 'N/A',
-        'Tarefa': task?.title || 'Sem tarefa',
         'Duração': formatDuration(session.durationSec),
       };
     });
@@ -120,6 +120,7 @@ export default function ReportsPage() {
   };
 
   return (
+    <>
     <div className="p-6 max-w-7xl mx-auto">
       <div className="flex items-center justify-between mb-8">
         <div>
@@ -130,6 +131,9 @@ export default function ReportsPage() {
         </div>
 
         <div className="flex gap-2">
+          <Button onClick={() => setManualOpen(true)} className="bg-blue-600 hover:bg-blue-700">
+            Adicionar Sessão
+          </Button>
           <Button onClick={handleExportSessions} variant="outline">
             <Download className="h-4 w-4 mr-2" />
             Exportar CSV
@@ -374,5 +378,7 @@ export default function ReportsPage() {
         )}
       </Card>
     </div>
+    <ManualSessionDialog open={manualOpen} onOpenChange={setManualOpen} />
+    </>
   );
 }

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -17,8 +17,8 @@ export default function SettingsPage() {
   
   const [settings, setSettings] = useState(pomodoroSettings);
 
-  const handleSaveSettings = () => {
-    updatePomodoroSettings(settings);
+  const handleSaveSettings = async () => {
+    await updatePomodoroSettings(settings);
     toast({
       title: "Configurações salvas",
       description: "As configurações do Pomodoro foram atualizadas.",

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -4,15 +4,16 @@ import { useState } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { 
-  LayoutDashboard, 
-  FolderKanban, 
-  CheckSquare, 
-  Calendar, 
-  Timer, 
-  BarChart3, 
+  LayoutDashboard,
+  FolderKanban,
+  CheckSquare,
+  Calendar,
+  CalendarDays,
+  Timer,
+  BarChart3,
   Settings,
   ChevronLeft,
-  ChevronRight 
+  ChevronRight
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
@@ -22,6 +23,7 @@ const navigation = [
   { name: 'Projetos', href: '/projects', icon: FolderKanban },
   { name: 'Tarefas', href: '/tasks', icon: CheckSquare },
   { name: 'Planejamento', href: '/plan', icon: Calendar },
+  { name: 'Calendário', href: '/calendar', icon: CalendarDays },
   { name: 'Foco', href: '/focus', icon: Timer },
   { name: 'Relatórios', href: '/reports', icon: BarChart3 },
   { name: 'Configurações', href: '/settings', icon: Settings },

--- a/components/sessions/ManualSessionDialog.tsx
+++ b/components/sessions/ManualSessionDialog.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useState } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { useAppStore } from '@/stores/useAppStore';
+
+interface ManualSessionDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function ManualSessionDialog({ open, onOpenChange }: ManualSessionDialogProps) {
+  const { projects, tasks, addSession } = useAppStore();
+  const [projectId, setProjectId] = useState('');
+  const [taskId, setTaskId] = useState('');
+  const [date, setDate] = useState('');
+  const [startTime, setStartTime] = useState('');
+  const [endTime, setEndTime] = useState('');
+
+  const projectTasks = projectId ? tasks.filter(t => t.projectId === projectId) : [];
+
+  const handleSave = async () => {
+    if (!projectId || !date || !startTime || !endTime) return;
+    const start = new Date(`${date}T${startTime}:00`);
+    const end = new Date(`${date}T${endTime}:00`);
+    const durationSec = Math.max(0, Math.floor((end.getTime() - start.getTime()) / 1000));
+    await addSession({
+      projectId,
+      taskId: taskId || undefined,
+      start: start.toISOString(),
+      end: end.toISOString(),
+      durationSec,
+      type: 'manual',
+    });
+    onOpenChange(false);
+    setProjectId('');
+    setTaskId('');
+    setDate('');
+    setStartTime('');
+    setEndTime('');
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="bg-gray-900 border-gray-800">
+        <DialogHeader>
+          <DialogTitle className="text-white">Adicionar Sessão Manual</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div>
+            <label className="block text-sm text-gray-300 mb-2">Projeto *</label>
+            <Select value={projectId} onValueChange={setProjectId}>
+              <SelectTrigger className="bg-gray-800 border-gray-700">
+                <SelectValue placeholder="Selecione" />
+              </SelectTrigger>
+              <SelectContent className="bg-gray-800 border-gray-700">
+                {projects.map(p => (
+                  <SelectItem key={p.id} value={p.id}>{p.name}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          {projectTasks.length > 0 && (
+            <div>
+              <label className="block text-sm text-gray-300 mb-2">Tarefa</label>
+              <Select value={taskId} onValueChange={setTaskId}>
+                <SelectTrigger className="bg-gray-800 border-gray-700">
+                  <SelectValue placeholder="Opcional" />
+                </SelectTrigger>
+                <SelectContent className="bg-gray-800 border-gray-700">
+                  <SelectItem value="">Sem tarefa</SelectItem>
+                  {projectTasks.map(t => (
+                    <SelectItem key={t.id} value={t.id}>{t.title}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm text-gray-300 mb-2">Data *</label>
+              <Input type="date" value={date} onChange={e => setDate(e.target.value)} className="bg-gray-800 border-gray-700" />
+            </div>
+            <div>
+              <label className="block text-sm text-gray-300 mb-2">Início *</label>
+              <Input type="time" value={startTime} onChange={e => setStartTime(e.target.value)} className="bg-gray-800 border-gray-700" />
+            </div>
+            <div>
+              <label className="block text-sm text-gray-300 mb-2">Fim *</label>
+              <Input type="time" value={endTime} onChange={e => setEndTime(e.target.value)} className="bg-gray-800 border-gray-700" />
+            </div>
+          </div>
+          <div className="pt-4 flex gap-2">
+            <Button variant="outline" className="flex-1" onClick={() => onOpenChange(false)}>Cancelar</Button>
+            <Button className="flex-1 bg-blue-600 hover:bg-blue-700" onClick={handleSave} disabled={!projectId || !date || !startTime || !endTime}>Salvar</Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -273,15 +273,18 @@ export const storage = {
 
   /**
    * ---------------------------
-   * Pomodoro (local)
+   * Pomodoro (database)
    * ---------------------------
    */
-  getPomodoroSettings(): PomodoroSettings {
-    return readLS<PomodoroSettings>(LS_KEYS.pomo, getDefaultPomodoroSettings());
+  async getPomodoroSettings(): Promise<PomodoroSettings> {
+    return request<PomodoroSettings>('/api/settings');
   },
 
-  setPomodoroSettings(settings: PomodoroSettings): void {
-    writeLS(LS_KEYS.pomo, settings);
+  async setPomodoroSettings(settings: PomodoroSettings): Promise<void> {
+    await request<PomodoroSettings>('/api/settings', {
+      method: 'PATCH',
+      body: settings,
+    });
   },
 
   /**

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -129,26 +129,34 @@ export function exportToCsv(data: any[], filename: string) {
 export function exportToPdf(data: any[], filename: string) {
   if (data.length === 0) return;
 
-  const doc = new jsPDF();
+  const doc = new jsPDF({ orientation: 'landscape' });
   const headers = Object.keys(data[0]);
-  const columnWidth = 190 / headers.length;
+  const pageWidth = doc.internal.pageSize.getWidth();
+  const pageHeight = doc.internal.pageSize.getHeight();
+  const columnWidth = (pageWidth - 20) / headers.length;
   let y = 10;
 
+  doc.setFontSize(10);
   headers.forEach((header, i) => {
-    doc.text(header, 10 + i * columnWidth, y);
+    doc.text(header, 10 + i * columnWidth, y, { maxWidth: columnWidth - 2 });
   });
 
-  y += 6;
+  y += 8;
 
   data.forEach(row => {
     headers.forEach((header, i) => {
       const text = String(row[header] ?? '');
-      doc.text(text, 10 + i * columnWidth, y);
+      const lines = doc.splitTextToSize(text, columnWidth - 2);
+      doc.text(lines, 10 + i * columnWidth, y);
     });
-    y += 6;
-    if (y > 280) {
+    y += 8;
+    if (y > pageHeight - 10) {
       doc.addPage();
       y = 10;
+      headers.forEach((header, i) => {
+        doc.text(header, 10 + i * columnWidth, y, { maxWidth: columnWidth - 2 });
+      });
+      y += 8;
     }
   });
 

--- a/prisma/migrations/20250906120000_add_pomodoro_settings/migration.sql
+++ b/prisma/migrations/20250906120000_add_pomodoro_settings/migration.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "PomodoroSettings" (
+  "id" TEXT NOT NULL,
+  "workMin" INTEGER NOT NULL,
+  "shortBreakMin" INTEGER NOT NULL,
+  "longBreakMin" INTEGER NOT NULL,
+  "cyclesToLongBreak" INTEGER NOT NULL,
+  "autoStartNext" BOOLEAN NOT NULL,
+  "soundOn" BOOLEAN NOT NULL,
+  CONSTRAINT "PomodoroSettings_pkey" PRIMARY KEY ("id")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -80,3 +80,13 @@ model DailyPlanBlock {
   projectId     String
   targetMinutes Int
 }
+
+model PomodoroSettings {
+  id               String  @id @default(cuid())
+  workMin          Int
+  shortBreakMin    Int
+  longBreakMin     Int
+  cyclesToLongBreak Int
+  autoStartNext    Boolean
+  soundOn          Boolean
+}

--- a/stores/useAppStore.ts
+++ b/stores/useAppStore.ts
@@ -26,7 +26,7 @@ interface AppStore {
   updateSession: (id: string, updates: Partial<FocusSession>) => Promise<void>;
   deleteSession: (id: string) => Promise<void>;
 
-  updatePomodoroSettings: (settings: Partial<PomodoroSettings>) => void;
+  updatePomodoroSettings: (settings: Partial<PomodoroSettings>) => Promise<void>;
 
   updateDailyPlan: (plan: DailyPlan) => void;
   getDailyPlan: (dateISO: string) => DailyPlan | undefined;
@@ -54,12 +54,12 @@ export const useAppStore = create<AppStore>((set, get) => ({
   theme: 'dark',
 
   initializeData: async () => {
-    const [projects, tasks, sessions] = await Promise.all([
+    const [projects, tasks, sessions, pomodoroSettings] = await Promise.all([
       storage.getProjects(),
       storage.getTasks(),
       storage.getSessions(),
+      storage.getPomodoroSettings(),
     ]);
-    const pomodoroSettings = storage.getPomodoroSettings();
     const dailyPlans = storage.getDailyPlans();
     set({ projects, tasks, sessions, pomodoroSettings, dailyPlans });
   },
@@ -119,12 +119,10 @@ export const useAppStore = create<AppStore>((set, get) => ({
   },
 
   // Settings
-  updatePomodoroSettings: (settings) => {
-    set((state) => {
-      const newSettings = { ...state.pomodoroSettings, ...settings };
-      storage.setPomodoroSettings(newSettings);
-      return { pomodoroSettings: newSettings };
-    });
+  updatePomodoroSettings: async (settings) => {
+    const newSettings = { ...get().pomodoroSettings, ...settings };
+    await storage.setPomodoroSettings(newSettings);
+    set({ pomodoroSettings: newSettings });
   },
 
   // Daily Plans


### PR DESCRIPTION
## Summary
- improve PDF export with landscape orientation and streamlined columns
- persist pomodoro configuration in database via new settings API and model
- allow manual session entry and add calendar page with month/week/day views

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch Inter font from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68c1707d29ac832bbd660c683a8ce4e8