### PR TITLE
fix: respect persisted settings, keep timer running and add save feedback

### DIFF
--- a/app/plan/page.tsx
+++ b/app/plan/page.tsx
@@ -5,6 +5,7 @@ import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { useAppStore } from '@/stores/useAppStore';
+import { useToast } from '@/hooks/use-toast';
 import { ProjectBadge } from '@/components/ui/project-badge';
 import { formatDuration, getProjectHoursToday } from '@/lib/utils';
 import { Progress } from '@/components/ui/progress';
@@ -22,6 +23,7 @@ import { ptBR } from 'date-fns/locale';
 
 export default function PlanPage() {
   const { projects, dailyPlans, sessions, updateDailyPlan, getDailyPlan } = useAppStore();
+  const { toast } = useToast();
   
   const today = format(new Date(), 'yyyy-MM-dd');
   const todayPlan = getDailyPlan(today);
@@ -78,8 +80,9 @@ export default function PlanPage() {
       blocks: blocks.filter(block => block.targetMinutes > 0),
       notes: notes.trim() || undefined,
     };
-    
+
     updateDailyPlan(planData);
+    toast({ title: 'Plano salvo' });
   };
 
   return (

--- a/components/focus/PomodoroTimer.tsx
+++ b/components/focus/PomodoroTimer.tsx
@@ -26,27 +26,9 @@ export function PomodoroTimer() {
     stopTimer,
     resetTimer,
     nextPhase,
-    tick,
-    restoreState,
   } = useTimerStore();
 
   const { projects, tasks } = useAppStore();
-
-  // Restore timer state on mount
-  useEffect(() => {
-    restoreState();
-  }, [restoreState]);
-
-  // Timer tick effect
-  useEffect(() => {
-    if (isRunning && !isPaused) {
-      const interval = setInterval(() => {
-        tick();
-      }, 1000);
-      
-      return () => clearInterval(interval);
-    }
-  }, [isRunning, isPaused, tick]);
 
   // Keyboard shortcuts
   useEffect(() => {

--- a/components/layout/TopNav.tsx
+++ b/components/layout/TopNav.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Search, Play, Pause, RotateCcw } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -13,16 +13,17 @@ export function TopNav() {
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [isFocusDialogOpen, setIsFocusDialogOpen] = useState(false);
   
-  const { 
-    isRunning, 
-    isPaused, 
-    timeRemaining, 
+  const {
+    isRunning,
+    isPaused,
+    timeRemaining,
     currentPhase,
     selectedProjectId,
-    pauseTimer, 
-    resumeTimer, 
-    stopTimer,
-    resetTimer 
+    pauseTimer,
+    resumeTimer,
+    resetTimer,
+    tick,
+    restoreState,
   } = useTimerStore();
   
   const { projects } = useAppStore();
@@ -33,6 +34,20 @@ export function TopNav() {
       setIsSearchOpen(false);
     }
   };
+
+  useEffect(() => {
+    restoreState();
+  }, [restoreState]);
+
+  useEffect(() => {
+    if (isRunning && !isPaused) {
+      const interval = setInterval(() => {
+        tick();
+      }, 1000);
+
+      return () => clearInterval(interval);
+    }
+  }, [isRunning, isPaused, tick]);
 
   return (
     <>

--- a/components/projects/ProjectDialog.tsx
+++ b/components/projects/ProjectDialog.tsx
@@ -7,6 +7,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Project } from '@/types';
 import { useAppStore } from '@/stores/useAppStore';
+import { useToast } from '@/hooks/use-toast';
 
 interface ProjectDialogProps {
   open: boolean;
@@ -21,6 +22,7 @@ const defaultColors = [
 
 export function ProjectDialog({ open, onOpenChange, project }: ProjectDialogProps) {
   const { addProject, updateProject } = useAppStore();
+  const { toast } = useToast();
   
   const [name, setName] = useState('');
   const [client, setClient] = useState('');
@@ -41,7 +43,7 @@ export function ProjectDialog({ open, onOpenChange, project }: ProjectDialogProp
     }
   }, [project, open]);
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     if (!name.trim()) return;
 
     const projectData = {
@@ -53,9 +55,11 @@ export function ProjectDialog({ open, onOpenChange, project }: ProjectDialogProp
     };
 
     if (project) {
-      updateProject(project.id, projectData);
+      await updateProject(project.id, projectData);
+      toast({ title: 'Projeto atualizado' });
     } else {
-      addProject(projectData);
+      await addProject(projectData);
+      toast({ title: 'Projeto criado' });
     }
 
     onOpenChange(false);

--- a/components/sessions/ManualSessionDialog.tsx
+++ b/components/sessions/ManualSessionDialog.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useAppStore } from '@/stores/useAppStore';
+import { useToast } from '@/hooks/use-toast';
 
 interface ManualSessionDialogProps {
   open: boolean;
@@ -14,6 +15,7 @@ interface ManualSessionDialogProps {
 
 export function ManualSessionDialog({ open, onOpenChange }: ManualSessionDialogProps) {
   const { projects, tasks, addSession } = useAppStore();
+  const { toast } = useToast();
   const [projectId, setProjectId] = useState('');
   const [taskId, setTaskId] = useState('');
   const [date, setDate] = useState('');
@@ -35,6 +37,7 @@ export function ManualSessionDialog({ open, onOpenChange }: ManualSessionDialogP
       durationSec,
       type: 'manual',
     });
+    toast({ title: 'Sessão adicionada' });
     onOpenChange(false);
     setProjectId('');
     setTaskId('');
@@ -66,12 +69,15 @@ export function ManualSessionDialog({ open, onOpenChange }: ManualSessionDialogP
           {projectTasks.length > 0 && (
             <div>
               <label className="block text-sm text-gray-300 mb-2">Tarefa</label>
-              <Select value={taskId} onValueChange={setTaskId}>
+              <Select
+                value={taskId}
+                onValueChange={value => setTaskId(value === 'none' ? '' : value)}
+              >
                 <SelectTrigger className="bg-gray-800 border-gray-700">
                   <SelectValue placeholder="Opcional" />
                 </SelectTrigger>
                 <SelectContent className="bg-gray-800 border-gray-700">
-                  <SelectItem value="">Sem tarefa</SelectItem>
+                  <SelectItem value="none">Sem tarefa</SelectItem>
                   {projectTasks.map(t => (
                     <SelectItem key={t.id} value={t.id}>{t.title}</SelectItem>
                   ))}

--- a/components/tasks/TaskDialog.tsx
+++ b/components/tasks/TaskDialog.tsx
@@ -9,6 +9,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Textarea } from '@/components/ui/textarea';
 import { useAppStore } from '@/stores/useAppStore';
 import { Task } from '@/types';
+import { useToast } from '@/hooks/use-toast';
 
 interface TaskDialogProps {
     open: boolean;
@@ -19,6 +20,7 @@ interface TaskDialogProps {
 
 export function TaskDialog({ open, onOpenChange, task, defaultProjectId }: TaskDialogProps) {
     const { projects, addTask, updateTask } = useAppStore();
+    const { toast } = useToast();
 
     const activeProjects = useMemo(() => projects.filter(p => p.active), [projects]);
 
@@ -59,8 +61,10 @@ export function TaskDialog({ open, onOpenChange, task, defaultProjectId }: TaskD
 
         if (task) {
             await updateTask(task.id, payload as Partial<Task>);
+            toast({ title: 'Tarefa atualizada' });
         } else {
             await addTask(payload);
+            toast({ title: 'Tarefa criada' });
         }
 
         onOpenChange(false);

--- a/stores/useTimerStore.ts
+++ b/stores/useTimerStore.ts
@@ -32,10 +32,7 @@ export const useTimerStore = create<TimerStore>((set, get) => ({
   elapsedInCycle: 0,
 
   startTimer: (type, projectId, taskId) => {
-    const pomodoroSettings = JSON.parse(
-      localStorage.getItem('focusforge/pomodoro-settings') ||
-        '{"workMin":50,"shortBreakMin":10,"longBreakMin":20,"cyclesToLongBreak":3,"autoStartNext":true,"soundOn":true}'
-    );
+    const pomodoroSettings = useAppStore.getState().pomodoroSettings;
 
     const totalTime = type === 'pomodoro' ? pomodoroSettings.workMin * 60 : 25 * 60;
 
@@ -152,10 +149,7 @@ export const useTimerStore = create<TimerStore>((set, get) => ({
 
   nextPhase: () => {
     const state = get();
-    const pomodoroSettings = JSON.parse(
-      localStorage.getItem('focusforge/pomodoro-settings') ||
-        '{"workMin":50,"shortBreakMin":10,"longBreakMin":20,"cyclesToLongBreak":3,"autoStartNext":true,"soundOn":true}'
-    );
+    const pomodoroSettings = useAppStore.getState().pomodoroSettings;
 
     if (state.currentPhase === 'work') {
       const isLongBreak = state.currentCycle >= state.cycles;
@@ -193,10 +187,7 @@ export const useTimerStore = create<TimerStore>((set, get) => ({
       get().saveState();
     } else {
       if (state.currentPhase !== 'manual') {
-        const pomodoroSettings = JSON.parse(
-          localStorage.getItem('focusforge/pomodoro-settings') ||
-            '{"workMin":50,"shortBreakMin":10,"longBreakMin":20,"cyclesToLongBreak":3,"autoStartNext":true,"soundOn":true}'
-        );
+        const pomodoroSettings = useAppStore.getState().pomodoroSettings;
 
         // Persist finished phase as a session (typically a work phase)
         if (state.selectedProjectId && state.sessionStart && state.currentPhase === 'work') {


### PR DESCRIPTION
## Summary
- use pomodoro settings from database-backed store instead of localStorage
- show toast messages after saving projects, tasks, manual sessions and daily plans
- avoid empty value for "Sem tarefa" option in manual session dialog
- keep timer running when navigating away so countdown only stops if user pauses

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c43d470dcc832b914cbdd024a08817