### PR TITLE
Track timer ticks with real-time elapsed timestamps

### DIFF
--- a/types/index.ts
+++ b/types/index.ts
@@ -59,5 +59,6 @@ export interface TimerState {
   selectedProjectId?: string;
   selectedTaskId?: string;
   sessionStart?: string;
+  lastTickAt?: string;
   elapsedInCycle: number;
 }


### PR DESCRIPTION
## Summary
- add a persisted lastTickAt marker to TimerState for reconstructing elapsed time
- overhaul the timer store to maintain lastTickAt, fast-forward phases based on real time, and sync state during restore

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68cd6d73c180832b9a76657129838895