### PR TITLE
Add list view for projects page

### DIFF
--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,19 +1,118 @@
 'use client';
 
 import { useState } from 'react';
+import { format, isToday } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
 import { Button } from '@/components/ui/button';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { useAppStore } from '@/stores/useAppStore';
 import { ProjectCard } from '@/components/projects/ProjectCard';
 import { ProjectDialog } from '@/components/projects/ProjectDialog';
+import { ProjectListItem } from '@/components/projects/ProjectListItem';
 import { Project } from '@/types';
-import { Plus } from 'lucide-react';
+import { LayoutGrid, List, Plus } from 'lucide-react';
 
 export default function ProjectsPage() {
-  const { projects } = useAppStore();
+  const { projects, tasks } = useAppStore();
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [editingProject, setEditingProject] = useState<Project | undefined>();
+  const [viewMode, setViewMode] = useState<'list' | 'grid'>('list');
 
   const activeProjects = projects.filter(p => p.active);
+
+  const parseToDate = (value: unknown): Date | null => {
+    if (!value) return null;
+
+    if (value instanceof Date && !Number.isNaN(value.getTime())) {
+      return value;
+    }
+
+    if (typeof value === 'number') {
+      const dateFromNumber = new Date(value);
+      return Number.isNaN(dateFromNumber.getTime()) ? null : dateFromNumber;
+    }
+
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      if (!trimmed) return null;
+
+      const normalized = trimmed.toLowerCase();
+      if (normalized === 'today' || normalized === 'hoje') {
+        return new Date();
+      }
+
+      const dateFromString = new Date(trimmed);
+      return Number.isNaN(dateFromString.getTime()) ? null : dateFromString;
+    }
+
+    return null;
+  };
+
+  const formatDateLabel = (date: Date): string => {
+    if (isToday(date)) {
+      return 'Hoje';
+    }
+
+    return format(date, 'dd/MM/yyyy', { locale: ptBR });
+  };
+
+  const getNextTaskDate = (projectId: string): Date | null => {
+    const projectTasks = tasks.filter(task => task.projectId === projectId && task.plannedFor);
+
+    const normalizedDates = projectTasks
+      .map(task => parseToDate(task.plannedFor))
+      .filter((date): date is Date => Boolean(date))
+      .sort((a, b) => a.getTime() - b.getTime());
+
+    return normalizedDates[0] ?? null;
+  };
+
+  const getProjectPlannedDateLabel = (project: Project): string => {
+    const meta = project as Record<string, unknown>;
+    const candidateKeys = [
+      'expectedDate',
+      'expectedAt',
+      'expectedDelivery',
+      'dueDate',
+      'forecastDate',
+      'deliveryDate',
+      'plannedDelivery',
+    ];
+
+    for (const key of candidateKeys) {
+      const parsed = parseToDate(meta[key]);
+      if (parsed) {
+        return formatDateLabel(parsed);
+      }
+    }
+
+    const nextTaskDate = getNextTaskDate(project.id);
+    if (nextTaskDate) {
+      return formatDateLabel(nextTaskDate);
+    }
+
+    return '—';
+  };
+
+  const getProjectNewUrlsLabel = (project: Project): string => {
+    const meta = project as Record<string, unknown>;
+    const candidateKeys = ['newUrls', 'new_urls', 'newUrlsCount', 'urlsNovas', 'novasUrls'];
+
+    for (const key of candidateKeys) {
+      const value = meta[key];
+      if (Array.isArray(value)) {
+        return value.length.toString();
+      }
+      if (typeof value === 'number') {
+        return value.toString();
+      }
+      if (typeof value === 'string' && value.trim()) {
+        return value;
+      }
+    }
+
+    return '—';
+  };
 
   const handleEdit = (project: Project) => {
     setEditingProject(project);
@@ -34,33 +133,86 @@ export default function ProjectsPage() {
 
   return (
     <div className="p-6 max-w-7xl mx-auto">
-      <div className="flex items-center justify-between mb-8">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between mb-8">
         <div>
           <h1 className="text-3xl font-bold text-white mb-2">Projetos</h1>
           <p className="text-gray-400">
             Gerencie seus projetos e acompanhe o progresso
           </p>
         </div>
-        
-        <Button 
-          onClick={handleNewProject}
-          className="bg-blue-600 hover:bg-blue-700"
-        >
-          <Plus className="h-4 w-4 mr-2" />
-          Novo Projeto
-        </Button>
+
+        <div className="flex flex-col-reverse gap-3 sm:flex-row sm:items-center">
+          <ToggleGroup
+            type="single"
+            value={viewMode}
+            onValueChange={(value) => {
+              if (value === 'list' || value === 'grid') {
+                setViewMode(value);
+              }
+            }}
+            className="self-start rounded-lg border border-gray-800 bg-gray-900/60 p-1 text-gray-300"
+            aria-label="Alternar visualização"
+          >
+            <ToggleGroupItem
+              value="list"
+              className="flex items-center gap-2 rounded-md px-3 py-2 text-sm data-[state=on]:bg-blue-600 data-[state=on]:text-white"
+              aria-label="Visualização em lista"
+            >
+              <List className="h-4 w-4" />
+              <span className="hidden sm:inline">Lista</span>
+            </ToggleGroupItem>
+            <ToggleGroupItem
+              value="grid"
+              className="flex items-center gap-2 rounded-md px-3 py-2 text-sm data-[state=on]:bg-blue-600 data-[state=on]:text-white"
+              aria-label="Visualização em cards"
+            >
+              <LayoutGrid className="h-4 w-4" />
+              <span className="hidden sm:inline">Cards</span>
+            </ToggleGroupItem>
+          </ToggleGroup>
+
+          <Button
+            onClick={handleNewProject}
+            className="bg-blue-600 hover:bg-blue-700"
+          >
+            <Plus className="h-4 w-4 mr-2" />
+            Novo Projeto
+          </Button>
+        </div>
       </div>
 
       {activeProjects.length > 0 ? (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {activeProjects.map((project) => (
-            <ProjectCard 
-              key={project.id} 
-              project={project} 
-              onEdit={handleEdit}
-            />
-          ))}
-        </div>
+        viewMode === 'list' ? (
+          <div className="space-y-3">
+            <div className="hidden md:grid md:grid-cols-[1.6fr_1fr_1fr_1fr_auto] px-4 text-xs font-semibold uppercase tracking-wide text-gray-500">
+              <span>Projeto</span>
+              <span>Cliente</span>
+              <span>Novas URLs</span>
+              <span>Data prevista</span>
+              <span className="text-right">Ações</span>
+            </div>
+
+            {activeProjects.map(project => (
+              <ProjectListItem
+                key={project.id}
+                project={project}
+                onEdit={handleEdit}
+                newUrlsLabel={getProjectNewUrlsLabel(project)}
+                plannedDateLabel={getProjectPlannedDateLabel(project)}
+              />
+            ))}
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {activeProjects.map(project => (
+              <ProjectCard
+                key={project.id}
+                project={project}
+                onEdit={handleEdit}
+              />
+            ))}
+          </div>
+        )
       ) : (
         <div className="text-center py-12">
           <p className="text-gray-400 mb-4">Nenhum projeto ativo encontrado</p>

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -68,7 +68,7 @@ export default function ProjectsPage() {
   };
 
   const getProjectPlannedDateLabel = (project: Project): string => {
-    const meta = project as Record<string, unknown>;
+    const meta = project as unknown as Record<string, unknown>;
     const candidateKeys = [
       'expectedDate',
       'expectedAt',
@@ -95,7 +95,7 @@ export default function ProjectsPage() {
   };
 
   const getProjectNewUrlsLabel = (project: Project): string => {
-    const meta = project as Record<string, unknown>;
+    const meta = project as unknown as Record<string, unknown>;
     const candidateKeys = ['newUrls', 'new_urls', 'newUrlsCount', 'urlsNovas', 'novasUrls'];
 
     for (const key of candidateKeys) {
@@ -222,8 +222,8 @@ export default function ProjectsPage() {
         </div>
       )}
 
-      <ProjectDialog 
-        open={isDialogOpen} 
+      <ProjectDialog
+        open={isDialogOpen}
         onOpenChange={handleCloseDialog}
         project={editingProject}
       />

--- a/components/projects/ProjectListItem.tsx
+++ b/components/projects/ProjectListItem.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { Project } from '@/types';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Calendar, Edit, Link2 } from 'lucide-react';
+
+interface ProjectListItemProps {
+  project: Project;
+  onEdit: (project: Project) => void;
+  newUrlsLabel: string;
+  plannedDateLabel: string;
+}
+
+export function ProjectListItem({
+  project,
+  onEdit,
+  newUrlsLabel,
+  plannedDateLabel,
+}: ProjectListItemProps) {
+  const isClockfyLinked = Boolean(project.clockfyProjectId);
+  const clockfyStatus = project.syncWithClockfy
+    ? isClockfyLinked
+      ? 'linked'
+      : 'pending'
+    : 'disabled';
+
+  const badgeClassName =
+    clockfyStatus === 'linked'
+      ? 'bg-emerald-500/20 border-emerald-500/40 text-emerald-300'
+      : clockfyStatus === 'pending'
+        ? 'border-yellow-500/60 text-yellow-300'
+        : 'border-gray-600 text-gray-300';
+
+  const badgeLabel =
+    clockfyStatus === 'linked'
+      ? 'Clockfy conectado'
+      : clockfyStatus === 'pending'
+        ? 'Clockfy pendente'
+        : 'Clockfy desativado';
+
+  const newUrlsIsEmpty = newUrlsLabel === '—' || newUrlsLabel === '0';
+  const dateIsEmpty = plannedDateLabel === '—';
+
+  return (
+    <div className="grid gap-3 rounded-lg border border-gray-800 bg-gray-900/50 p-4 transition-colors hover:bg-gray-900 md:grid-cols-[1.6fr_1fr_1fr_1fr_auto] md:items-center">
+      <div className="flex items-start gap-3">
+        <div
+          className="mt-1 h-2.5 w-2.5 flex-shrink-0 rounded-full"
+          style={{ backgroundColor: project.color }}
+        />
+        <div>
+          <p className="font-medium text-white">{project.name}</p>
+          <Badge
+            variant={clockfyStatus === 'linked' ? 'secondary' : 'outline'}
+            className={`mt-2 h-5 px-2 text-xs ${badgeClassName}`}
+          >
+            {badgeLabel}
+          </Badge>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2 text-sm text-gray-300">
+        <span className="md:hidden text-xs font-semibold uppercase tracking-wide text-gray-500">
+          Cliente
+        </span>
+        <span className={project.client ? 'text-white' : 'text-gray-500'}>
+          {project.client || '—'}
+        </span>
+      </div>
+
+      <div className="flex items-center gap-2 text-sm text-gray-300">
+        <span className="md:hidden text-xs font-semibold uppercase tracking-wide text-gray-500">
+          Novas URLs
+        </span>
+        <Link2 className="h-4 w-4 text-gray-500" />
+        <span className={newUrlsIsEmpty ? 'text-gray-400' : 'text-white font-medium'}>
+          {newUrlsLabel}
+        </span>
+      </div>
+
+      <div className="flex items-center gap-2 text-sm text-gray-300">
+        <span className="md:hidden text-xs font-semibold uppercase tracking-wide text-gray-500">
+          Data prevista
+        </span>
+        <Calendar className="h-4 w-4 text-gray-500" />
+        <span className={dateIsEmpty ? 'text-gray-400' : 'text-white font-medium'}>
+          {plannedDateLabel}
+        </span>
+      </div>
+
+      <div className="flex justify-start md:justify-end">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => onEdit(project)}
+          className="border-gray-700 text-gray-200 hover:bg-gray-800 hover:text-white"
+        >
+          <Edit className="mr-2 h-4 w-4" />
+          Editar
+        </Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a view mode toggle to the projects page with list selected by default
- derive planned date and "novas URLs" labels from project metadata/tasks while keeping existing filters and edit dialog usage
- implement a ProjectListItem component to render each project row with the expected details and shared actions

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68cf0e97bba0832ba5a069349df280e7