### PR TITLE
Add project metadata fields and surface UI updates

### DIFF
--- a/app/api/projects/[id]/route.ts
+++ b/app/api/projects/[id]/route.ts
@@ -11,8 +11,46 @@ export async function PATCH(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const {id} = await params;
+    const { id } = await params;
     const body = await req.json();
+    const optionalUrlSchema = z
+      .string()
+      .trim()
+      .optional()
+      .nullable()
+      .transform((value) => {
+        if (value === undefined) return undefined;
+        if (value === null) return null;
+        return value.length > 0 ? value : undefined;
+      });
+
+    const estimatedDateSchema = z
+      .union([z.string(), z.date()])
+      .optional()
+      .nullable()
+      .transform((value, ctx) => {
+        if (value === undefined) return undefined;
+        if (value === null) return null;
+
+        if (value instanceof Date) {
+          if (Number.isNaN(value.getTime())) {
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'Data inválida' });
+            return z.NEVER;
+          }
+          return value;
+        }
+
+        const trimmed = value.trim();
+        if (!trimmed) return undefined;
+
+        const parsedDate = new Date(trimmed);
+        if (Number.isNaN(parsedDate.getTime())) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'Data inválida' });
+          return z.NEVER;
+        }
+
+        return parsedDate;
+      });
     const schema = z.object({
       name: z.string().min(1).optional(),
       client: z.string().optional().nullable(),
@@ -24,6 +62,9 @@ export async function PATCH(
         .refine((v) => v === undefined || Number.isFinite(v), 'hourlyRate inválido'),
       active: z.boolean().optional(),
       syncWithClockfy: z.boolean().optional(),
+      salesforceOppUrl: optionalUrlSchema,
+      sharepointRepoUrl: optionalUrlSchema,
+      estimatedDeliveryDate: estimatedDateSchema,
     });
 
     const parsed = schema.parse(body);
@@ -34,6 +75,9 @@ export async function PATCH(
     if (parsed.color !== undefined) data.color = parsed.color;
     if (parsed.hourlyRate !== undefined) data.hourlyRate = parsed.hourlyRate;
     if (parsed.active !== undefined) data.active = parsed.active;
+    if (parsed.salesforceOppUrl !== undefined) data.salesforceOppUrl = parsed.salesforceOppUrl;
+    if (parsed.sharepointRepoUrl !== undefined) data.sharepointRepoUrl = parsed.sharepointRepoUrl;
+    if (parsed.estimatedDeliveryDate !== undefined) data.estimatedDeliveryDate = parsed.estimatedDeliveryDate;
     if (parsed.syncWithClockfy !== undefined) {
       data.syncWithClockfy = parsed.syncWithClockfy;
       if (parsed.syncWithClockfy === false) {

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -6,6 +6,7 @@ import { useAppStore } from '@/stores/useAppStore';
 import { ProjectCard } from '@/components/projects/ProjectCard';
 import { ProjectDialog } from '@/components/projects/ProjectDialog';
 import { Project } from '@/types';
+import { formatFriendlyDate } from '@/lib/utils';
 import { Plus } from 'lucide-react';
 
 export default function ProjectsPage() {
@@ -51,11 +52,87 @@ export default function ProjectsPage() {
         </Button>
       </div>
 
+      {activeProjects.length > 0 && (
+        <div className="mb-8 overflow-x-auto rounded-lg border border-gray-800 bg-gray-900/40">
+          <table className="min-w-full divide-y divide-gray-800 text-sm">
+            <thead className="bg-gray-900/60">
+              <tr>
+                <th className="px-4 py-3 text-left font-semibold text-gray-300">Projeto</th>
+                <th className="px-4 py-3 text-left font-semibold text-gray-300">Salesforce</th>
+                <th className="px-4 py-3 text-left font-semibold text-gray-300">SharePoint</th>
+                <th className="px-4 py-3 text-left font-semibold text-gray-300">Entrega prevista</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-800">
+              {activeProjects.map((project) => {
+                const formattedDate = project.estimatedDeliveryDate
+                  ? formatFriendlyDate(project.estimatedDeliveryDate)
+                  : null;
+
+                return (
+                  <tr key={`project-list-${project.id}`} className="hover:bg-gray-900/60">
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-3">
+                        <span
+                          className="inline-flex h-2.5 w-2.5 rounded-full"
+                          style={{ backgroundColor: project.color }}
+                        />
+                        <div>
+                          <p className="font-medium text-white">{project.name}</p>
+                          {project.client && (
+                            <p className="text-xs text-gray-400">{project.client}</p>
+                          )}
+                        </div>
+                      </div>
+                    </td>
+                    <td className="px-4 py-3">
+                      {project.salesforceOppUrl ? (
+                        <a
+                          href={project.salesforceOppUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-blue-400 hover:text-blue-300 underline"
+                        >
+                          Ver oportunidade
+                        </a>
+                      ) : (
+                        <span className="text-gray-500">—</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3">
+                      {project.sharepointRepoUrl ? (
+                        <a
+                          href={project.sharepointRepoUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-blue-400 hover:text-blue-300 underline"
+                        >
+                          Ver repositório
+                        </a>
+                      ) : (
+                        <span className="text-gray-500">—</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3">
+                      {formattedDate ? (
+                        <span className="text-white">{formattedDate}</span>
+                      ) : (
+                        <span className="text-gray-500">—</span>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
       {activeProjects.length > 0 ? (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {activeProjects.map((project) => (
-            <ProjectCard 
-              key={project.id} 
+            <ProjectCard
+              key={project.id}
               project={project} 
               onEdit={handleEdit}
             />

--- a/components/projects/ProjectCard.tsx
+++ b/components/projects/ProjectCard.tsx
@@ -5,7 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Project } from '@/types';
 import { useAppStore } from '@/stores/useAppStore';
-import { formatDuration, getProjectHoursToday, getWeekHours } from '@/lib/utils';
+import { formatDuration, formatFriendlyDate, getProjectHoursToday, getWeekHours } from '@/lib/utils';
 import { MoreVertical, Edit, Archive, Play } from 'lucide-react';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 
@@ -25,6 +25,10 @@ export function ProjectCard({ project, onEdit }: ProjectCardProps) {
   const pendingTasks = tasks.filter(t =>
     t.projectId === project.id && t.status !== 'done'
   ).length;
+
+  const estimatedDelivery = project.estimatedDeliveryDate
+    ? formatFriendlyDate(project.estimatedDeliveryDate)
+    : null;
 
   const isClockfyLinked = Boolean(project.clockfyProjectId);
   const clockfyStatus = project.syncWithClockfy
@@ -117,6 +121,44 @@ export function ProjectCard({ project, onEdit }: ProjectCardProps) {
           </div>
         )}
       </div>
+
+      {(project.salesforceOppUrl || project.sharepointRepoUrl || estimatedDelivery) && (
+        <div className="mt-4 space-y-2 rounded-lg border border-gray-800 bg-gray-900/40 p-4">
+          <p className="text-xs uppercase tracking-wide text-gray-400">Metadados</p>
+          {project.salesforceOppUrl && (
+            <div className="flex items-center justify-between gap-2 text-sm">
+              <span className="text-gray-400">Salesforce</span>
+              <a
+                href={project.salesforceOppUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-400 hover:text-blue-300 underline"
+              >
+                Abrir oportunidade
+              </a>
+            </div>
+          )}
+          {project.sharepointRepoUrl && (
+            <div className="flex items-center justify-between gap-2 text-sm">
+              <span className="text-gray-400">SharePoint</span>
+              <a
+                href={project.sharepointRepoUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-400 hover:text-blue-300 underline"
+              >
+                Abrir repositório
+              </a>
+            </div>
+          )}
+          {estimatedDelivery && (
+            <div className="flex items-center justify-between gap-2 text-sm">
+              <span className="text-gray-400">Entrega prevista</span>
+              <span className="text-white font-medium">{estimatedDelivery}</span>
+            </div>
+          )}
+        </div>
+      )}
 
       <Button className="w-full mt-4 bg-blue-600 hover:bg-blue-700">
         <Play className="h-4 w-4 mr-2" />

--- a/components/projects/ProjectDialog.tsx
+++ b/components/projects/ProjectDialog.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { format } from 'date-fns';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -30,6 +31,9 @@ export function ProjectDialog({ open, onOpenChange, project }: ProjectDialogProp
   const [color, setColor] = useState(defaultColors[0]);
   const [hourlyRate, setHourlyRate] = useState('');
   const [syncWithClockfy, setSyncWithClockfy] = useState(false);
+  const [salesforceOppUrl, setSalesforceOppUrl] = useState('');
+  const [sharepointRepoUrl, setSharepointRepoUrl] = useState('');
+  const [estimatedDeliveryDate, setEstimatedDeliveryDate] = useState('');
 
   useEffect(() => {
     if (project) {
@@ -38,18 +42,39 @@ export function ProjectDialog({ open, onOpenChange, project }: ProjectDialogProp
       setColor(project.color);
       setHourlyRate(project.hourlyRate?.toString() || '');
       setSyncWithClockfy(project.syncWithClockfy);
+      setSalesforceOppUrl(project.salesforceOppUrl || '');
+      setSharepointRepoUrl(project.sharepointRepoUrl || '');
+
+      if (project.estimatedDeliveryDate) {
+        const dateValue =
+          project.estimatedDeliveryDate instanceof Date
+            ? project.estimatedDeliveryDate
+            : new Date(project.estimatedDeliveryDate);
+        if (!Number.isNaN(dateValue.getTime())) {
+          setEstimatedDeliveryDate(format(dateValue, 'yyyy-MM-dd'));
+        } else {
+          setEstimatedDeliveryDate('');
+        }
+      } else {
+        setEstimatedDeliveryDate('');
+      }
     } else {
       setName('');
       setClient('');
       setColor(defaultColors[0]);
       setHourlyRate('');
       setSyncWithClockfy(false);
+      setSalesforceOppUrl('');
+      setSharepointRepoUrl('');
+      setEstimatedDeliveryDate('');
     }
   }, [project, open]);
 
   const handleSubmit = async () => {
     if (!name.trim()) return;
 
+    const trimmedSalesforceUrl = salesforceOppUrl.trim();
+    const trimmedSharepointUrl = sharepointRepoUrl.trim();
     const projectData = {
       name: name.trim(),
       client: client.trim() || undefined,
@@ -57,6 +82,9 @@ export function ProjectDialog({ open, onOpenChange, project }: ProjectDialogProp
       hourlyRate: hourlyRate ? parseFloat(hourlyRate) : undefined,
       active: true,
       syncWithClockfy,
+      salesforceOppUrl: trimmedSalesforceUrl ? trimmedSalesforceUrl : null,
+      sharepointRepoUrl: trimmedSharepointUrl ? trimmedSharepointUrl : null,
+      estimatedDeliveryDate: estimatedDeliveryDate ? estimatedDeliveryDate : null,
     };
 
     if (project) {
@@ -126,6 +154,41 @@ export function ProjectDialog({ open, onOpenChange, project }: ProjectDialogProp
               value={hourlyRate}
               onChange={(e) => setHourlyRate(e.target.value)}
               placeholder="150.00"
+              className="bg-gray-800 border-gray-700 text-white"
+            />
+          </div>
+
+          <div>
+            <Label htmlFor="salesforceOppUrl" className="text-gray-300">URL da oportunidade no Salesforce</Label>
+            <Input
+              id="salesforceOppUrl"
+              type="url"
+              value={salesforceOppUrl}
+              onChange={(e) => setSalesforceOppUrl(e.target.value)}
+              placeholder="https://..."
+              className="bg-gray-800 border-gray-700 text-white"
+            />
+          </div>
+
+          <div>
+            <Label htmlFor="sharepointRepoUrl" className="text-gray-300">URL do repositório no SharePoint</Label>
+            <Input
+              id="sharepointRepoUrl"
+              type="url"
+              value={sharepointRepoUrl}
+              onChange={(e) => setSharepointRepoUrl(e.target.value)}
+              placeholder="https://..."
+              className="bg-gray-800 border-gray-700 text-white"
+            />
+          </div>
+
+          <div>
+            <Label htmlFor="estimatedDeliveryDate" className="text-gray-300">Data prevista de entrega</Label>
+            <Input
+              id="estimatedDeliveryDate"
+              type="date"
+              value={estimatedDeliveryDate}
+              onChange={(e) => setEstimatedDeliveryDate(e.target.value)}
               className="bg-gray-800 border-gray-700 text-white"
             />
           </div>

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -11,11 +11,19 @@ export function cn(...inputs: ClassValue[]) {
 export function formatDuration(seconds: number): string {
   const hours = Math.floor(seconds / 3600);
   const minutes = Math.floor((seconds % 3600) / 60);
-  
+
   if (hours > 0) {
     return `${hours}h ${minutes}m`;
   }
   return `${minutes}m`;
+}
+
+export function formatFriendlyDate(value: string | Date): string {
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+  return format(date, 'dd/MM/yyyy');
 }
 
 export function formatTime(seconds: number): string {

--- a/prisma/migrations/20250910120000_project_metadata_fields/migration.sql
+++ b/prisma/migrations/20250910120000_project_metadata_fields/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "public"."Project" ADD COLUMN     "estimatedDeliveryDate" TIMESTAMP(3),
+ADD COLUMN     "salesforceOppUrl" TEXT,
+ADD COLUMN     "sharepointRepoUrl" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,6 +38,9 @@ model Project {
   clockfyClientId   String?
   clockfyProjectId  String?
   syncWithClockfy   Boolean          @default(false)
+  salesforceOppUrl      String?
+  sharepointRepoUrl     String?
+  estimatedDeliveryDate DateTime?
 }
 
 model Task {

--- a/types/index.ts
+++ b/types/index.ts
@@ -9,6 +9,9 @@ export interface Project {
   clockfyClientId?: string | null;
   clockfyProjectId?: string | null;
   syncWithClockfy: boolean;
+  salesforceOppUrl?: string | null;
+  sharepointRepoUrl?: string | null;
+  estimatedDeliveryDate?: string | Date | null;
 }
 
 export interface Task {


### PR DESCRIPTION
## Summary
- add optional Salesforce, SharePoint, and estimated delivery date fields to the Project schema and types, including a generated migration
- extend project API validation to parse the new metadata values and persist them through the store
- capture and display the new project metadata in the dialog, list view, and cards with friendly formatting and links

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf0ea41358832b8c46fba78dfcb75f