### PR TITLE
Handle null task fields when clearing data

### DIFF
--- a/app/api/tasks/[id]/route.ts
+++ b/app/api/tasks/[id]/route.ts
@@ -26,12 +26,20 @@ export async function PATCH(
 
     const parsed = schema.parse(body);
 
-    const data: any = {};
+    const data: {
+      projectId?: string;
+      title?: string;
+      description?: string | null;
+      priority?: 'alta' | 'media' | 'baixa';
+      plannedFor?: string | null;
+      status?: 'todo' | 'doing' | 'done';
+      estimateMin?: number;
+    } = {};
     if (parsed.projectId !== undefined) data.projectId = parsed.projectId;
     if (parsed.title !== undefined) data.title = parsed.title;
-    if (parsed.description !== undefined) data.description = parsed.description || undefined;
+    if (parsed.description !== undefined) data.description = parsed.description ?? null;
     if (parsed.priority !== undefined) data.priority = parsed.priority;
-    if (parsed.plannedFor !== undefined) data.plannedFor = parsed.plannedFor || undefined;
+    if (parsed.plannedFor !== undefined) data.plannedFor = parsed.plannedFor ?? null;
     if (parsed.status !== undefined) data.status = parsed.status;
     if (parsed.estimateMin !== undefined) data.estimateMin = parsed.estimateMin;
 

--- a/app/api/tasks/route.ts
+++ b/app/api/tasks/route.ts
@@ -27,15 +27,37 @@ export async function POST(req: Request) {
 
     const parsed = schema.parse(body);
 
-    const data = {
+    const bodyHasDescription =
+      typeof body === 'object' && body !== null && Object.prototype.hasOwnProperty.call(body, 'description');
+    const bodyHasPlannedFor =
+      typeof body === 'object' && body !== null && Object.prototype.hasOwnProperty.call(body, 'plannedFor');
+
+    const data: {
+      projectId: string;
+      title: string;
+      priority: 'alta' | 'media' | 'baixa';
+      status: 'todo' | 'doing' | 'done';
+      description?: string | null;
+      plannedFor?: string | null;
+      estimateMin?: number;
+    } = {
       projectId: parsed.projectId,
       title: parsed.title,
-      description: parsed.description || undefined,
       priority: parsed.priority ?? 'media',
-      plannedFor: parsed.plannedFor || undefined,
       status: parsed.status ?? 'todo',
-      estimateMin: parsed.estimateMin !== undefined ? parsed.estimateMin : undefined,
     };
+
+    if (bodyHasDescription) {
+      data.description = parsed.description ?? null;
+    }
+
+    if (bodyHasPlannedFor) {
+      data.plannedFor = parsed.plannedFor ?? null;
+    }
+
+    if (parsed.estimateMin !== undefined) {
+      data.estimateMin = parsed.estimateMin;
+    }
 
     const task = await prisma.task.create({ data });
     return NextResponse.json(task);

--- a/components/tasks/TaskCard.tsx
+++ b/components/tasks/TaskCard.tsx
@@ -29,13 +29,13 @@ export function TaskCard({ task, onEdit }: TaskCardProps) {
     updateTask(task.id, { status: newStatus });
   };
 
+  const todayISO = new Date().toISOString().split('T')[0];
+  const isPlannedForToday = task.plannedFor === 'today' || task.plannedFor === todayISO;
+
   const handlePlanForToday = () => {
-    const newPlannedFor = task.plannedFor === 'today' ? undefined : 'today';
+    const newPlannedFor = isPlannedForToday ? null : 'today';
     updateTask(task.id, { plannedFor: newPlannedFor });
   };
-
-  const isPlannedForToday = task.plannedFor === 'today' ||
-    task.plannedFor === new Date().toISOString().split('T')[0];
 
   return (
     <Card className="p-4 bg-gray-900/50 border-gray-800 hover:bg-gray-900/70 transition-colors">

--- a/components/tasks/TaskDialog.tsx
+++ b/components/tasks/TaskDialog.tsx
@@ -51,13 +51,20 @@ export function TaskDialog({ open, onOpenChange, task, defaultProjectId }: TaskD
     const handleSubmit = async () => {
         if (!canSubmit) return;
 
-        const payload = {
+        const trimmedTitle = title.trim();
+        const trimmedDescription = description.trim();
+
+        const payload: Omit<Task, 'id' | 'createdAt'> = {
             projectId,
-            title: title.trim(),
-            description: description.trim() || undefined,
+            title: trimmedTitle,
             priority,
-            estimateMin: estimateMin ? parseInt(estimateMin, 10) : undefined,
-        } as Omit<Task, 'id' | 'createdAt'>;
+        };
+
+        payload.description = trimmedDescription === '' ? null : trimmedDescription;
+
+        if (estimateMin) {
+            payload.estimateMin = parseInt(estimateMin, 10);
+        }
 
         if (task) {
             await updateTask(task.id, payload as Partial<Task>);

--- a/types/index.ts
+++ b/types/index.ts
@@ -15,9 +15,9 @@ export interface Task {
   id: string;
   projectId: string;
   title: string;
-  description?: string;
+  description?: string | null;
   priority?: 'alta' | 'media' | 'baixa';
-  plannedFor?: 'today' | string; // dateISO
+  plannedFor?: 'today' | string | null; // dateISO
   status?: 'todo' | 'doing' | 'done';
   estimateMin?: number;
   createdAt: string;


### PR DESCRIPTION
## Summary
- send `null` when removing a task from today's plan and reuse the computed flag in the card
- normalize blank descriptions to `null`, updating the shared `Task` type accordingly
- persist explicit `null` values in the task API routes so cleared fields stay cleared

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68cf0ed4bffc832bb36f257a4090f89a