### PR TITLE
Add submission loading states to dialogs

### DIFF
--- a/components/projects/ProjectDialog.tsx
+++ b/components/projects/ProjectDialog.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { Loader2 } from 'lucide-react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -30,6 +31,7 @@ export function ProjectDialog({ open, onOpenChange, project }: ProjectDialogProp
   const [color, setColor] = useState(defaultColors[0]);
   const [hourlyRate, setHourlyRate] = useState('');
   const [syncWithClockfy, setSyncWithClockfy] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   useEffect(() => {
     if (project) {
@@ -50,24 +52,30 @@ export function ProjectDialog({ open, onOpenChange, project }: ProjectDialogProp
   const handleSubmit = async () => {
     if (!name.trim()) return;
 
-    const projectData = {
-      name: name.trim(),
-      client: client.trim() || undefined,
-      color,
-      hourlyRate: hourlyRate ? parseFloat(hourlyRate) : undefined,
-      active: true,
-      syncWithClockfy,
-    };
+    setIsSubmitting(true);
 
-    if (project) {
-      await updateProject(project.id, projectData);
-      toast({ title: 'Projeto atualizado' });
-    } else {
-      await addProject(projectData);
-      toast({ title: 'Projeto criado' });
+    try {
+      const projectData = {
+        name: name.trim(),
+        client: client.trim() || undefined,
+        color,
+        hourlyRate: hourlyRate ? parseFloat(hourlyRate) : undefined,
+        active: true,
+        syncWithClockfy,
+      };
+
+      if (project) {
+        await updateProject(project.id, projectData);
+        toast({ title: 'Projeto atualizado' });
+      } else {
+        await addProject(projectData);
+        toast({ title: 'Projeto criado' });
+      }
+
+      onOpenChange(false);
+    } finally {
+      setIsSubmitting(false);
     }
-
-    onOpenChange(false);
   };
 
   return (
@@ -152,12 +160,19 @@ export function ProjectDialog({ open, onOpenChange, project }: ProjectDialogProp
             >
               Cancelar
             </Button>
-            <Button 
+            <Button
               onClick={handleSubmit}
-              disabled={!name.trim()}
+              disabled={!name.trim() || isSubmitting}
               className="flex-1 bg-blue-600 hover:bg-blue-700"
             >
-              {project ? 'Atualizar' : 'Criar'}
+              {isSubmitting ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  {project ? 'Atualizando...' : 'Criando...'}
+                </>
+              ) : (
+                project ? 'Atualizar' : 'Criar'
+              )}
             </Button>
           </div>
         </div>

--- a/components/tasks/TaskDialog.tsx
+++ b/components/tasks/TaskDialog.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
+import { Loader2 } from 'lucide-react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -29,6 +30,7 @@ export function TaskDialog({ open, onOpenChange, task, defaultProjectId }: TaskD
     const [description, setDescription] = useState('');
     const [priority, setPriority] = useState<'alta' | 'media' | 'baixa'>('media');
     const [estimateMin, setEstimateMin] = useState<string>('');
+    const [isSubmitting, setIsSubmitting] = useState(false);
 
     useEffect(() => {
         if (task) {
@@ -49,25 +51,31 @@ export function TaskDialog({ open, onOpenChange, task, defaultProjectId }: TaskD
     const canSubmit = Boolean(projectId && title.trim());
 
     const handleSubmit = async () => {
-        if (!canSubmit) return;
+        if (!canSubmit || isSubmitting) return;
 
-        const payload = {
-            projectId,
-            title: title.trim(),
-            description: description.trim() || undefined,
-            priority,
-            estimateMin: estimateMin ? parseInt(estimateMin, 10) : undefined,
-        } as Omit<Task, 'id' | 'createdAt'>;
+        setIsSubmitting(true);
 
-        if (task) {
-            await updateTask(task.id, payload as Partial<Task>);
-            toast({ title: 'Tarefa atualizada' });
-        } else {
-            await addTask(payload);
-            toast({ title: 'Tarefa criada' });
+        try {
+            const payload = {
+                projectId,
+                title: title.trim(),
+                description: description.trim() || undefined,
+                priority,
+                estimateMin: estimateMin ? parseInt(estimateMin, 10) : undefined,
+            } as Omit<Task, 'id' | 'createdAt'>;
+
+            if (task) {
+                await updateTask(task.id, payload as Partial<Task>);
+                toast({ title: 'Tarefa atualizada' });
+            } else {
+                await addTask(payload);
+                toast({ title: 'Tarefa criada' });
+            }
+
+            onOpenChange(false);
+        } finally {
+            setIsSubmitting(false);
         }
-
-        onOpenChange(false);
     };
 
     return (
@@ -160,10 +168,17 @@ export function TaskDialog({ open, onOpenChange, task, defaultProjectId }: TaskD
                         </Button>
                         <Button
                             onClick={handleSubmit}
-                            disabled={!canSubmit}
+                            disabled={!canSubmit || isSubmitting}
                             className="flex-1 bg-blue-600 hover:bg-blue-700"
                         >
-                            {task ? 'Atualizar' : 'Criar'}
+                            {isSubmitting ? (
+                                <>
+                                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                    {task ? 'Atualizando...' : 'Criando...'}
+                                </>
+                            ) : (
+                                task ? 'Atualizar' : 'Criar'
+                            )}
                         </Button>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- add submission state handling to the project, task, and manual session dialogs
- disable primary actions and show a loader while requests are running
- reset dialog fields only after a successful submission so the loader remains visible

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf0eebcc74832b9b4654e48a08868c