### PR TITLE
Enhance focus workflows and filtering

### DIFF
--- a/app/(protected)/settings/page.tsx
+++ b/app/(protected)/settings/page.tsx
@@ -9,7 +9,7 @@ import { Switch } from '@/components/ui/switch';
 import { useAppStore } from '@/stores/useAppStore';
 import { Slider } from '@/components/ui/slider';
 import { Badge } from '@/components/ui/badge';
-import { Settings, Download, Upload, Trash2, PlugZap, CheckCircle2, AlertCircle } from 'lucide-react';
+import { Settings, Download, Upload, Trash2, PlugZap, CheckCircle2, AlertCircle, Loader2 } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 
 export default function SettingsPage() {
@@ -30,6 +30,8 @@ export default function SettingsPage() {
     apiKey: clockfySettings.apiKey,
     workspaceId: clockfySettings.workspaceId,
   });
+  const [isSavingSettings, setIsSavingSettings] = useState(false);
+  const [isSavingClockfy, setIsSavingClockfy] = useState(false);
 
   useEffect(() => {
     setClockfyForm({
@@ -39,14 +41,26 @@ export default function SettingsPage() {
   }, [clockfySettings]);
 
   const handleSaveSettings = async () => {
-    await updatePomodoroSettings(settings);
-    toast({
-      title: "Configurações salvas",
-      description: "As configurações do Pomodoro foram atualizadas.",
-    });
+    setIsSavingSettings(true);
+    try {
+      await updatePomodoroSettings(settings);
+      toast({
+        title: 'Configurações salvas',
+        description: 'As configurações do Pomodoro foram atualizadas.',
+      });
+    } catch (error) {
+      toast({
+        title: 'Não foi possível salvar',
+        description: 'Tente novamente em instantes.',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsSavingSettings(false);
+    }
   };
 
   const handleSaveClockfy = async () => {
+    setIsSavingClockfy(true);
     try {
       await updateClockfySettings(clockfyForm);
       toast({
@@ -59,6 +73,8 @@ export default function SettingsPage() {
         description: 'Verifique as credenciais informadas.',
         variant: 'destructive',
       });
+    } finally {
+      setIsSavingClockfy(false);
     }
   };
 
@@ -223,8 +239,16 @@ export default function SettingsPage() {
           <Button
             onClick={handleSaveSettings}
             className="mt-6 bg-blue-600 hover:bg-blue-700"
+            disabled={isSavingSettings}
           >
-            Salvar Configurações
+            {isSavingSettings ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Salvando...
+              </>
+            ) : (
+              'Salvar Configurações'
+            )}
           </Button>
         </Card>
 
@@ -275,8 +299,16 @@ export default function SettingsPage() {
           <Button
             onClick={handleSaveClockfy}
             className="mt-6 bg-blue-600 hover:bg-blue-700"
+            disabled={isSavingClockfy}
           >
-            Salvar credenciais
+            {isSavingClockfy ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Salvando...
+              </>
+            ) : (
+              'Salvar credenciais'
+            )}
           </Button>
 
           <div className="mt-8">

--- a/app/(protected)/tasks/page.tsx
+++ b/app/(protected)/tasks/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useAppStore } from '@/stores/useAppStore';
@@ -11,6 +11,7 @@ import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
 import { getTodayTasks } from '@/lib/utils';
 import { TaskDialog } from '@/components/tasks/TaskDialog';
+import { useSearchParams } from 'next/navigation';
 
 export default function TasksPage() {
   const { tasks, projects } = useAppStore();
@@ -18,17 +19,9 @@ export default function TasksPage() {
   const [showOnlyToday, setShowOnlyToday] = useState(false);
   const [editingTask, setEditingTask] = useState<Task | undefined>();
   const [isDialogOpen, setIsDialogOpen] = useState(false);
-  const [searchQuery, setSearchQuery] = useState('');
-  const [focusId, setFocusId] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    const params = new URLSearchParams(window.location.search);
-    setSearchQuery(params.get('search') ?? '');
-    setFocusId(params.get('focusId') ?? null);
-  }, []);
-
-  const searchTerm = searchQuery.trim().toLowerCase();
+  const searchParams = useSearchParams();
+  const searchTerm = (searchParams.get('search') ?? '').trim().toLowerCase();
+  const focusId = searchParams.get('focusId');
   const filteredTasks = tasks.filter(task => {
     if (selectedProjectId !== 'all' && task.projectId !== selectedProjectId) {
       return false;

--- a/app/mini-timer/layout.tsx
+++ b/app/mini-timer/layout.tsx
@@ -1,0 +1,15 @@
+import { AppProvider } from '@/components/providers/AppProvider';
+import { Toaster } from '@/components/ui/sonner';
+
+export default function MiniTimerLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <AppProvider>
+      {children}
+      <Toaster theme="dark" />
+    </AppProvider>
+  );
+}

--- a/app/mini-timer/page.tsx
+++ b/app/mini-timer/page.tsx
@@ -1,0 +1,9 @@
+import { MiniTimer } from '@/components/focus/MiniTimer';
+
+export default function MiniTimerPage() {
+  return (
+    <div className="min-h-screen bg-gray-950 text-white flex items-center justify-center p-6">
+      <MiniTimer />
+    </div>
+  );
+}

--- a/components/focus/FocusDialog.tsx
+++ b/components/focus/FocusDialog.tsx
@@ -3,13 +3,20 @@
 import { useState } from 'react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useAppStore } from '@/stores/useAppStore';
 import { useTimerStore } from '@/stores/useTimerStore';
-import { ProjectBadge } from '@/components/ui/project-badge';
 import { PriorityTag } from '@/components/ui/priority-tag';
-import { getTodayTasks } from '@/lib/utils';
-import { Play, Timer } from 'lucide-react';
+import { getTodayTasks, cn } from '@/lib/utils';
+import { Play, Timer, ChevronsUpDown, Check } from 'lucide-react';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
 
 interface FocusDialogProps {
   open: boolean;
@@ -23,12 +30,20 @@ export function FocusDialog({ open, onOpenChange }: FocusDialogProps) {
   const [selectedProjectId, setSelectedProjectId] = useState<string>('');
   const [selectedTaskId, setSelectedTaskId] = useState<string>('');
   const [timerType, setTimerType] = useState<'pomodoro' | 'manual'>('pomodoro');
+  const [isProjectOpen, setIsProjectOpen] = useState(false);
+  const [isTaskOpen, setIsTaskOpen] = useState(false);
 
   const activeProjects = projects.filter(p => p.active);
   const todayTasks = getTodayTasks(tasks);
   const projectTasks = selectedProjectId
     ? tasks.filter(t => t.projectId === selectedProjectId && t.status !== 'done')
     : [];
+  const selectedProject = selectedProjectId
+    ? activeProjects.find(project => project.id === selectedProjectId)
+    : undefined;
+  const selectedTask = selectedTaskId && selectedTaskId !== 'none'
+    ? projectTasks.find(task => task.id === selectedTaskId)
+    : undefined;
 
   const handleStart = () => {
     if (!selectedProjectId) return;
@@ -84,24 +99,71 @@ export function FocusDialog({ open, onOpenChange }: FocusDialogProps) {
             <label className="block text-sm font-medium text-gray-300 mb-2">
               Projeto *
             </label>
-            <Select value={selectedProjectId} onValueChange={setSelectedProjectId}>
-              <SelectTrigger className="bg-gray-800 border-gray-700">
-                <SelectValue placeholder="Selecione um projeto" />
-              </SelectTrigger>
-              <SelectContent className="bg-gray-800 border-gray-700">
-                {activeProjects.map((project) => (
-                  <SelectItem key={project.id} value={project.id}>
-                    <div className="flex items-center gap-2">
-                      <div
+            <Popover open={isProjectOpen} onOpenChange={setIsProjectOpen}>
+              <PopoverTrigger asChild>
+                <Button
+                  variant="outline"
+                  role="combobox"
+                  aria-expanded={isProjectOpen}
+                  className="w-full justify-between bg-gray-800 border-gray-700 text-left text-gray-200"
+                >
+                  {selectedProject ? (
+                    <span className="flex items-center gap-2 truncate">
+                      <span
                         className="w-3 h-3 rounded-full"
-                        style={{ backgroundColor: project.color }}
+                        style={{ backgroundColor: selectedProject.color }}
                       />
-                      <span>{project.name}</span>
-                    </div>
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+                      <span className="truncate">{selectedProject.name}</span>
+                    </span>
+                  ) : (
+                    <span className="text-gray-500">Selecione um projeto</span>
+                  )}
+                  <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent
+                className="w-[320px] p-0 bg-gray-900 border border-gray-800"
+                align="start"
+              >
+                <Command>
+                  <CommandInput placeholder="Buscar projeto..." className="text-gray-200" />
+                  <CommandList>
+                    <CommandEmpty className="text-gray-400 py-6">
+                      Nenhum projeto encontrado.
+                    </CommandEmpty>
+                    <CommandGroup>
+                      {activeProjects.map((project) => (
+                        <CommandItem
+                          key={project.id}
+                          value={`${project.name} ${project.client ?? ''}`}
+                          onSelect={() => {
+                            setSelectedProjectId(project.id);
+                            setSelectedTaskId('');
+                            setIsProjectOpen(false);
+                            setIsTaskOpen(false);
+                          }}
+                          className="text-gray-200"
+                        >
+                          <div className="flex items-center gap-2 flex-1 overflow-hidden">
+                            <span
+                              className="w-3 h-3 rounded-full"
+                              style={{ backgroundColor: project.color }}
+                            />
+                            <span className="truncate">{project.name}</span>
+                          </div>
+                          <Check
+                            className={cn(
+                              'h-4 w-4',
+                              selectedProjectId === project.id ? 'opacity-100' : 'opacity-0'
+                            )}
+                          />
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  </CommandList>
+                </Command>
+              </PopoverContent>
+            </Popover>
           </div>
 
           {/* Task Selection (optional) */}
@@ -110,22 +172,85 @@ export function FocusDialog({ open, onOpenChange }: FocusDialogProps) {
               <label className="block text-sm font-medium text-gray-300 mb-2">
                 Tarefa (opcional)
               </label>
-              <Select value={selectedTaskId} onValueChange={setSelectedTaskId}>
-                <SelectTrigger className="bg-gray-800 border-gray-700">
-                  <SelectValue placeholder="Selecione uma tarefa" />
-                </SelectTrigger>
-                <SelectContent className="bg-gray-800 border-gray-700">
-                  <SelectItem value="none">Sem tarefa específica</SelectItem>
-                  {projectTasks.map((task) => (
-                    <SelectItem key={task.id} value={task.id}>
-                      <div className="flex items-center gap-2">
-                        <PriorityTag priority={task.priority || 'media'} />
-                        <span className="truncate">{task.title}</span>
-                      </div>
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <Popover open={isTaskOpen} onOpenChange={setIsTaskOpen}>
+                <PopoverTrigger asChild>
+                  <Button
+                    variant="outline"
+                    role="combobox"
+                    aria-expanded={isTaskOpen}
+                    className="w-full justify-between bg-gray-800 border-gray-700 text-left text-gray-200"
+                  >
+                    {selectedTaskId ? (
+                      <span className="flex items-center gap-2 truncate">
+                        {selectedTaskId === 'none' ? (
+                          <span className="truncate">Sem tarefa específica</span>
+                        ) : (
+                          <>
+                            <PriorityTag priority={selectedTask?.priority || 'media'} />
+                            <span className="truncate">{selectedTask?.title}</span>
+                          </>
+                        )}
+                      </span>
+                    ) : (
+                      <span className="text-gray-500">Selecione uma tarefa</span>
+                    )}
+                    <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent
+                  className="w-[320px] p-0 bg-gray-900 border border-gray-800"
+                  align="start"
+                >
+                  <Command>
+                    <CommandInput placeholder="Buscar tarefa..." className="text-gray-200" />
+                    <CommandList>
+                      <CommandEmpty className="text-gray-400 py-6">
+                        Nenhuma tarefa encontrada.
+                      </CommandEmpty>
+                      <CommandGroup>
+                        <CommandItem
+                          value="none"
+                          onSelect={() => {
+                            setSelectedTaskId('none');
+                            setIsTaskOpen(false);
+                          }}
+                          className="text-gray-200"
+                        >
+                          <span className="flex-1 truncate">Sem tarefa específica</span>
+                          <Check
+                            className={cn(
+                              'h-4 w-4',
+                              selectedTaskId === 'none' ? 'opacity-100' : 'opacity-0'
+                            )}
+                          />
+                        </CommandItem>
+                        {projectTasks.map((task) => (
+                          <CommandItem
+                            key={task.id}
+                            value={`${task.title} ${task.description ?? ''}`}
+                            onSelect={() => {
+                              setSelectedTaskId(task.id);
+                              setIsTaskOpen(false);
+                            }}
+                            className="text-gray-200"
+                          >
+                            <div className="flex items-center gap-2 flex-1 overflow-hidden">
+                              <PriorityTag priority={task.priority || 'media'} />
+                              <span className="truncate">{task.title}</span>
+                            </div>
+                            <Check
+                              className={cn(
+                                'h-4 w-4',
+                                selectedTaskId === task.id ? 'opacity-100' : 'opacity-0'
+                              )}
+                            />
+                          </CommandItem>
+                        ))}
+                      </CommandGroup>
+                    </CommandList>
+                  </Command>
+                </PopoverContent>
+              </Popover>
             </div>
           )}
 

--- a/components/focus/MiniTimer.tsx
+++ b/components/focus/MiniTimer.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+import { useTimerStore } from '@/stores/useTimerStore';
+import { useAppStore } from '@/stores/useAppStore';
+import { formatTime } from '@/lib/utils';
+import { Pause, Play, RotateCcw, Square } from 'lucide-react';
+
+const phaseLabels: Record<string, string> = {
+  work: 'Trabalho',
+  'short-break': 'Pausa Curta',
+  'long-break': 'Pausa Longa',
+  manual: 'Cronômetro',
+};
+
+const TIMER_STORAGE_KEY = 'focusforge/timer-state';
+
+export function MiniTimer() {
+  const {
+    isRunning,
+    isPaused,
+    currentPhase,
+    timeRemaining,
+    selectedProjectId,
+    selectedTaskId,
+    pauseTimer,
+    resumeTimer,
+    stopTimer,
+    resetTimer,
+    tick,
+    restoreState,
+  } = useTimerStore();
+
+  const { projects, tasks } = useAppStore();
+
+  useEffect(() => {
+    restoreState();
+  }, [restoreState]);
+
+  useEffect(() => {
+    if (isRunning && !isPaused) {
+      const id = setInterval(() => {
+        tick();
+      }, 1000);
+      return () => clearInterval(id);
+    }
+  }, [isRunning, isPaused, tick]);
+
+  useEffect(() => {
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === TIMER_STORAGE_KEY) {
+        restoreState();
+      }
+    };
+
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
+  }, [restoreState]);
+
+  const project = selectedProjectId
+    ? projects.find((p) => p.id === selectedProjectId)
+    : undefined;
+  const task = selectedTaskId
+    ? tasks.find((t) => t.id === selectedTaskId)
+    : undefined;
+
+  return (
+    <div className="w-full max-w-xs rounded-2xl border border-gray-800 bg-gray-900/80 p-4 shadow-xl">
+      <div className="flex items-center justify-between text-[11px] uppercase tracking-wide text-gray-400">
+        <span>{phaseLabels[currentPhase] ?? 'Sessão'}</span>
+        <span>{isRunning ? (isPaused ? 'Pausado' : 'Em andamento') : 'Parado'}</span>
+      </div>
+
+      <div className="mt-4 text-center">
+        <div className="text-5xl font-mono font-bold text-white">
+          {formatTime(Math.max(timeRemaining, 0))}
+        </div>
+
+        {project && (
+          <div className="mt-3 flex items-center justify-center gap-2 text-sm text-gray-200">
+            <span
+              className="h-2.5 w-2.5 rounded-full"
+              style={{ backgroundColor: project.color }}
+            />
+            <span className="truncate max-w-[180px]">{project.name}</span>
+          </div>
+        )}
+
+        {task && (
+          <p className="mt-1 text-xs text-gray-500 truncate max-w-[220px] mx-auto">
+            {task.title}
+          </p>
+        )}
+      </div>
+
+      <div className="mt-5 flex items-center justify-center gap-3">
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={isPaused ? resumeTimer : pauseTimer}
+          disabled={!isRunning}
+          className="h-8 w-8 p-0 text-gray-200 hover:text-white hover:bg-gray-800"
+        >
+          {isPaused ? <Play className="h-4 w-4" /> : <Pause className="h-4 w-4" />}
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={stopTimer}
+          disabled={!isRunning && !isPaused}
+          className="h-8 w-8 p-0 text-gray-200 hover:text-white hover:bg-gray-800"
+        >
+          <Square className="h-4 w-4" />
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={resetTimer}
+          disabled={!isRunning && !isPaused}
+          className="h-8 w-8 p-0 text-gray-200 hover:text-white hover:bg-gray-800"
+        >
+          <RotateCcw className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/layout/TopNav.tsx
+++ b/components/layout/TopNav.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
-import { Search, Play, Pause, RotateCcw, LogOut } from 'lucide-react';
+import { Search, Play, Pause, RotateCcw, LogOut, SquareArrowOutUpRight } from 'lucide-react';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import {
@@ -40,6 +40,11 @@ export function TopNav() {
 
   const { projects, tasks } = useAppStore();
   const selectedProject = projects.find(p => p.id === selectedProjectId);
+
+  const handleOpenMiniTimer = () => {
+    const features = 'width=360,height=260,menubar=no,toolbar=no,location=no,status=no';
+    window.open('/mini-timer', 'focusforge-mini-timer', features);
+  };
 
   const handleLogout = async () => {
     setIsLoggingOut(true);
@@ -172,6 +177,15 @@ export function TopNav() {
                 )}
 
                 <div className="flex items-center gap-1">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={handleOpenMiniTimer}
+                    className="h-8 w-8 p-0 hover:bg-gray-700"
+                    title="Abrir mini cronômetro"
+                  >
+                    <SquareArrowOutUpRight className="h-4 w-4" />
+                  </Button>
                   <Button
                     variant="ghost"
                     size="sm"

--- a/components/projects/ProjectDialog.tsx
+++ b/components/projects/ProjectDialog.tsx
@@ -109,7 +109,7 @@ export function ProjectDialog({ open, onOpenChange, project }: ProjectDialogProp
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="bg-gray-900 border-gray-800">
+      <DialogContent className="bg-gray-900 border-gray-800 max-h-[85vh] overflow-y-auto sm:max-h-[80vh]">
         <DialogHeader>
           <DialogTitle className="text-white">
             {project ? 'Editar Projeto' : 'Novo Projeto'}


### PR DESCRIPTION
## Summary
- ensure project and task pages react to in-page search parameters and improve the project dialog with a scrollable body
- upgrade the focus session dialog with searchable selectors, add a detachable mini timer view, and expose a shortcut button in the top navigation
- start daily plans empty, add saving feedback to planning and settings pages, and show spinner states while persisting changes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2f1e185c8832ba6944e57921c7a6d