### PR TITLE
Sync timer state across mini window

### DIFF
--- a/components/focus/MiniTimer.tsx
+++ b/components/focus/MiniTimer.tsx
@@ -6,6 +6,7 @@ import { useTimerStore } from '@/stores/useTimerStore';
 import { useAppStore } from '@/stores/useAppStore';
 import { formatTime } from '@/lib/utils';
 import { Pause, Play, RotateCcw, Square } from 'lucide-react';
+import { TIMER_STORAGE_KEY } from '@/lib/constants';
 
 const phaseLabels: Record<string, string> = {
   work: 'Trabalho',
@@ -13,8 +14,6 @@ const phaseLabels: Record<string, string> = {
   'long-break': 'Pausa Longa',
   manual: 'Cronômetro',
 };
-
-const TIMER_STORAGE_KEY = 'focusforge/timer-state';
 
 export function MiniTimer() {
   const {

--- a/components/layout/TopNav.tsx
+++ b/components/layout/TopNav.tsx
@@ -17,6 +17,7 @@ import { useTimerStore } from '@/stores/useTimerStore';
 import { useAppStore } from '@/stores/useAppStore';
 import { cn, formatTime } from '@/lib/utils';
 import { FocusDialog } from '@/components/focus/FocusDialog';
+import { TIMER_STORAGE_KEY } from '@/lib/constants';
 
 export function TopNav() {
   const router = useRouter();
@@ -107,6 +108,17 @@ export function TopNav() {
 
   useEffect(() => {
     restoreState();
+  }, [restoreState]);
+
+  useEffect(() => {
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === TIMER_STORAGE_KEY) {
+        restoreState();
+      }
+    };
+
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
   }, [restoreState]);
 
   useEffect(() => {

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,1 @@
+export const TIMER_STORAGE_KEY = 'focusforge/timer-state';


### PR DESCRIPTION
## Summary
- centralize the timer storage key so both windows reuse the same identifier
- listen for timer storage updates in the top navigation to refresh the store when mini timer actions run

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d54634d158832bab3b8e7b1fa09a8b