### PR TITLE
feat: manage sessions and persist daily plans

### DIFF
--- a/app/(protected)/plan/page.tsx
+++ b/app/(protected)/plan/page.tsx
@@ -82,8 +82,15 @@ export default function PlanPage() {
         notes: notes.trim() || undefined,
       };
 
-      await Promise.resolve(updateDailyPlan(planData));
+      await updateDailyPlan(planData);
       toast({ title: 'Plano salvo' });
+    } catch (error) {
+      console.error(error);
+      toast({
+        title: 'Erro ao salvar plano',
+        description: error instanceof Error ? error.message : undefined,
+        variant: 'destructive',
+      });
     } finally {
       setIsSaving(false);
     }

--- a/app/api/daily-plans/route.ts
+++ b/app/api/daily-plans/route.ts
@@ -1,0 +1,109 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { z } from 'zod';
+
+const planSchema = z.object({
+  id: z.string().optional(),
+  dateISO: z.string(),
+  notes: z.string().optional().nullable(),
+  blocks: z.array(
+    z.object({
+      projectId: z.string(),
+      targetMinutes: z.number().int().min(0),
+    })
+  ),
+});
+
+type PlanWithRelations = {
+  id: string;
+  date: Date;
+  notes: string | null;
+  blocks: { projectId: string; targetMinutes: number }[];
+};
+
+function mapPlan(plan: PlanWithRelations) {
+  return {
+    id: plan.id,
+    dateISO: plan.date.toISOString().slice(0, 10),
+    notes: plan.notes ?? undefined,
+    blocks: plan.blocks.map((block) => ({
+      projectId: block.projectId,
+      targetMinutes: block.targetMinutes,
+    })),
+  };
+}
+
+function getDateRange(dateISO: string) {
+  const start = new Date(`${dateISO}T00:00:00.000Z`);
+  if (Number.isNaN(start.getTime())) {
+    throw new Error('Data inválida');
+  }
+  const end = new Date(start.getTime());
+  end.setUTCDate(end.getUTCDate() + 1);
+  return { start, end };
+}
+
+export async function GET() {
+  const plans = await prisma.dailyPlan.findMany({
+    include: { blocks: true },
+    orderBy: { date: 'desc' },
+  });
+
+  return NextResponse.json(plans.map((plan) => mapPlan(plan as PlanWithRelations)));
+}
+
+export async function POST(req: Request) {
+  try {
+    const payload = planSchema.parse(await req.json());
+    const { start, end } = getDateRange(payload.dateISO);
+
+    const existing = await prisma.dailyPlan.findFirst({
+      where: {
+        date: {
+          gte: start,
+          lt: end,
+        },
+      },
+    });
+
+    const blocksData = payload.blocks.map((block) => ({
+      projectId: block.projectId,
+      targetMinutes: block.targetMinutes,
+    }));
+
+    const saved = existing
+      ? await prisma.dailyPlan.update({
+          where: { id: existing.id },
+          data: {
+            date: start,
+            notes: payload.notes?.trim() ? payload.notes : null,
+            blocks: {
+              deleteMany: {},
+              create: blocksData,
+            },
+          },
+          include: { blocks: true },
+        })
+      : await prisma.dailyPlan.create({
+          data: {
+            date: start,
+            notes: payload.notes?.trim() ? payload.notes : null,
+            blocks: {
+              create: blocksData,
+            },
+          },
+          include: { blocks: true },
+        });
+
+    return NextResponse.json(mapPlan(saved as PlanWithRelations));
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return NextResponse.json({ message: 'Dados inválidos', issues: err.issues }, { status: 400 });
+    }
+    if (err instanceof Error && err.message === 'Data inválida') {
+      return NextResponse.json({ message: err.message }, { status: 400 });
+    }
+    console.error(err);
+    return NextResponse.json({ message: 'Erro ao salvar plano diário' }, { status: 500 });
+  }
+}

--- a/components/dashboard/RecentSessions.tsx
+++ b/components/dashboard/RecentSessions.tsx
@@ -1,15 +1,51 @@
 'use client';
 
+import { useState } from 'react';
 import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
 import { useAppStore } from '@/stores/useAppStore';
 import { formatDuration } from '@/lib/utils';
 import { ProjectBadge } from '@/components/ui/project-badge';
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
+import { Trash2, Loader2 } from 'lucide-react';
+import { useToast } from '@/hooks/use-toast';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
 
 export function RecentSessions() {
-  const { sessions, projects, tasks } = useAppStore();
-  
+  const { sessions, projects, tasks, deleteSession } = useAppStore();
+  const { toast } = useToast();
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleDelete = async (id: string) => {
+    setIsDeleting(true);
+    try {
+      await deleteSession(id);
+      toast({ title: 'Sessão excluída' });
+    } catch (error) {
+      console.error(error);
+      toast({
+        title: 'Erro ao excluir sessão',
+        description: error instanceof Error ? error.message : undefined,
+        variant: 'destructive',
+      });
+    } finally {
+      setIsDeleting(false);
+      setPendingDeleteId(null);
+    }
+  };
+
   const recentSessions = sessions
     .sort((a, b) => new Date(b.start).getTime() - new Date(a.start).getTime())
     .slice(0, 8);
@@ -31,6 +67,8 @@ export function RecentSessions() {
             const startTime = format(new Date(session.start), "dd/MM 'às' HH:mm", { locale: ptBR });
             const endTime = session.end ? format(new Date(session.end), 'HH:mm', { locale: ptBR }) : '...';
 
+            const isTargetSession = pendingDeleteId === session.id;
+
             return (
               <div
                 key={session.id}
@@ -48,13 +86,59 @@ export function RecentSessions() {
                   </div>
                 </div>
 
-                <div className="text-right">
-                  <p className="text-sm font-medium text-white">
-                    {formatDuration(session.durationSec)}
-                  </p>
-                  <p className="text-xs text-gray-500 capitalize">
-                    {session.type}
-                  </p>
+                <div className="flex items-center gap-3">
+                  <div className="text-right">
+                    <p className="text-sm font-medium text-white">
+                      {formatDuration(session.durationSec)}
+                    </p>
+                    <p className="text-xs text-gray-500 capitalize">
+                      {session.type}
+                    </p>
+                  </div>
+
+                  <AlertDialog
+                    open={isTargetSession}
+                    onOpenChange={(open) => setPendingDeleteId(open ? session.id : null)}
+                  >
+                    <AlertDialogTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="text-gray-400 hover:text-red-400"
+                        aria-label="Excluir sessão"
+                        onClick={() => setPendingDeleteId(session.id)}
+                      >
+                        {isDeleting && isTargetSession ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <Trash2 className="h-4 w-4" />
+                        )}
+                      </Button>
+                    </AlertDialogTrigger>
+                    <AlertDialogContent className="bg-gray-900 border border-gray-700 text-white">
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>Excluir sessão</AlertDialogTitle>
+                        <AlertDialogDescription className="text-gray-300">
+                          Tem certeza que deseja remover esta sessão? Esta ação não pode ser desfeita.
+                        </AlertDialogDescription>
+                      </AlertDialogHeader>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel className="bg-gray-800 border border-gray-700 text-white">
+                          Cancelar
+                        </AlertDialogCancel>
+                        <AlertDialogAction
+                          className="bg-red-600 hover:bg-red-700"
+                          onClick={() => handleDelete(session.id)}
+                          disabled={isDeleting}
+                        >
+                          {isDeleting && isTargetSession ? (
+                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                          ) : null}
+                          Excluir
+                        </AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
                 </div>
               </div>
             );

--- a/lib/sound.ts
+++ b/lib/sound.ts
@@ -1,0 +1,37 @@
+let audioContext: AudioContext | null = null;
+
+type SoundType = 'start' | 'end';
+
+function getAudioContext(): AudioContext | null {
+  if (typeof window === 'undefined') return null;
+  const Ctor = window.AudioContext || (window as any).webkitAudioContext;
+  if (!Ctor) return null;
+  if (!audioContext) {
+    audioContext = new Ctor();
+  }
+  if (audioContext.state === 'suspended') {
+    void audioContext.resume().catch(() => undefined);
+  }
+  return audioContext;
+}
+
+export function playSessionSound(type: SoundType) {
+  const ctx = getAudioContext();
+  if (!ctx) return;
+
+  const oscillator = ctx.createOscillator();
+  oscillator.type = 'sine';
+  const baseFrequency = type === 'start' ? 880 : 440;
+  oscillator.frequency.setValueAtTime(baseFrequency, ctx.currentTime);
+
+  const gain = ctx.createGain();
+  gain.gain.setValueAtTime(0.0001, ctx.currentTime);
+  gain.gain.exponentialRampToValueAtTime(0.05, ctx.currentTime + 0.02);
+  gain.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + 0.6);
+
+  oscillator.connect(gain);
+  gain.connect(ctx.destination);
+
+  oscillator.start();
+  oscillator.stop(ctx.currentTime + 0.6);
+}

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -183,7 +183,6 @@ function getDefaultPomodoroSettings(): PomodoroSettings {
  */
 const LS_KEYS = {
   pomo: 'focusforge/pomodoro-settings',
-  plans: 'focusforge/daily-plans',
   timer: 'focusforge/timer-state',
 } as const;
 
@@ -305,15 +304,18 @@ export const storage = {
 
   /**
    * ---------------------------
-   * Daily Plans (local)
+   * Daily Plans (database)
    * ---------------------------
    */
-  getDailyPlans(): DailyPlan[] {
-    return readLS<DailyPlan[]>(LS_KEYS.plans, []);
+  async getDailyPlans(): Promise<DailyPlan[]> {
+    return request<DailyPlan[]>('/api/daily-plans');
   },
 
-  setDailyPlans(plans: DailyPlan[]): void {
-    writeLS(LS_KEYS.plans, plans);
+  async saveDailyPlan(plan: DailyPlan): Promise<DailyPlan> {
+    return request<DailyPlan>('/api/daily-plans', {
+      method: 'POST',
+      body: plan,
+    });
   },
 
   /**

--- a/stores/useTimerStore.ts
+++ b/stores/useTimerStore.ts
@@ -4,6 +4,7 @@ import { create } from 'zustand';
 import { PomodoroSettings, TimerState } from '@/types';
 import { storage } from '@/lib/storage';
 import { useAppStore } from '@/stores/useAppStore';
+import { playSessionSound } from '@/lib/sound';
 
 interface TimerStore extends TimerState {
   startTimer: (type: 'pomodoro' | 'manual', projectId: string, taskId?: string) => void;
@@ -191,6 +192,10 @@ export const useTimerStore = create<TimerStore>((set, get) => ({
     });
 
     get().saveState();
+
+    if (pomodoroSettings.soundOn) {
+      playSessionSound('start');
+    }
   },
 
   switchTask: (projectId, taskId) => {
@@ -209,6 +214,9 @@ export const useTimerStore = create<TimerStore>((set, get) => ({
         type: state.currentPhase === 'manual' ? ('manual' as const) : ('pomodoro' as const),
         pomodoroCycles: state.currentPhase === 'manual' ? undefined : state.currentCycle,
       };
+      if (useAppStore.getState().pomodoroSettings.soundOn) {
+        playSessionSound('end');
+      }
       storage.addSession(newSession).then((created) => {
         try {
           useAppStore.setState((prev) => ({ sessions: [...prev.sessions, created] }));
@@ -227,6 +235,10 @@ export const useTimerStore = create<TimerStore>((set, get) => ({
     });
 
     get().saveState();
+
+    if (useAppStore.getState().pomodoroSettings.soundOn) {
+      playSessionSound('start');
+    }
   },
 
   pauseTimer: () => {
@@ -256,6 +268,9 @@ export const useTimerStore = create<TimerStore>((set, get) => ({
           type: state.currentPhase === 'manual' ? ('manual' as const) : ('pomodoro' as const),
           pomodoroCycles: state.currentPhase === 'manual' ? undefined : state.currentCycle,
         };
+        if (useAppStore.getState().pomodoroSettings.soundOn) {
+          playSessionSound('end');
+        }
         storage.addSession(newSession).then((created) => {
           try {
             useAppStore.setState((prev) => ({ sessions: [...prev.sessions, created] }));
@@ -343,6 +358,10 @@ export const useTimerStore = create<TimerStore>((set, get) => ({
       });
     });
 
+    if (sessions.length > 0 && useAppStore.getState().pomodoroSettings.soundOn) {
+      playSessionSound('end');
+    }
+
     get().saveState();
   },
 
@@ -377,6 +396,10 @@ export const useTimerStore = create<TimerStore>((set, get) => ({
           } catch {}
         });
       });
+
+      if (sessions.length > 0 && useAppStore.getState().pomodoroSettings.soundOn) {
+        playSessionSound('end');
+      }
 
       get().saveState();
     } else {


### PR DESCRIPTION
## Summary
- add API support and storage wiring to persist daily plans in the database
- allow deleting recent sessions directly from the dashboard with confirmation feedback
- trigger audible notifications on session lifecycle events via a reusable sound helper

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68daa25fa2cc832bb8e61980af4ca66b