### PR TITLE
Add task comments and surface updates on projects

### DIFF
--- a/app/(protected)/projects/page.tsx
+++ b/app/(protected)/projects/page.tsx
@@ -176,6 +176,34 @@ export default function ProjectsPage() {
     return '—';
   };
 
+  const latestUpdatesByProject = useMemo(() => {
+    return tasks.reduce(
+      (acc, task) => {
+        const [mostRecent] = [...(task.comments ?? [])].sort(
+          (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+        );
+        if (!mostRecent) {
+          return acc;
+        }
+
+        const current = acc[task.projectId];
+        if (
+          !current ||
+          new Date(mostRecent.createdAt).getTime() > new Date(current.createdAt).getTime()
+        ) {
+          acc[task.projectId] = {
+            message: mostRecent.message,
+            createdAt: mostRecent.createdAt,
+            taskTitle: task.title,
+          };
+        }
+
+        return acc;
+      },
+      {} as Record<string, { message: string; createdAt: string; taskTitle: string }>
+    );
+  }, [tasks]);
+
   const handleEdit = (project: Project) => {
     setEditingProject(project);
     setIsDialogOpen(true);
@@ -263,6 +291,7 @@ export default function ProjectsPage() {
                 plannedDateLabel={getProjectPlannedDateLabel(project)}
                 salesforceUrl={project.salesforceOppUrl ?? null}
                 sharepointUrl={project.sharepointRepoUrl ?? null}
+                latestComment={latestUpdatesByProject[project.id]}
               />
             ))}
           </div>

--- a/app/api/tasks/[id]/comments/route.ts
+++ b/app/api/tasks/[id]/comments/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+export const dynamic = 'force-dynamic';
+import { z } from 'zod';
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const body = await req.json();
+    const schema = z.object({
+      message: z.string().min(1, 'Comentário obrigatório'),
+    });
+
+    const { message } = schema.parse(body);
+    const trimmedMessage = message.trim();
+
+    if (!trimmedMessage) {
+      return NextResponse.json({ message: 'Comentário obrigatório' }, { status: 400 });
+    }
+
+    const comment = await prisma.taskComment.create({
+      data: {
+        taskId: id,
+        message: trimmedMessage,
+      },
+    });
+
+    return NextResponse.json(comment);
+  } catch (err: any) {
+    const message = err?.message ?? 'Erro ao adicionar comentário';
+    return NextResponse.json({ message }, { status: 400 });
+  }
+}

--- a/app/api/tasks/[id]/route.ts
+++ b/app/api/tasks/[id]/route.ts
@@ -43,7 +43,15 @@ export async function PATCH(
     if (parsed.status !== undefined) data.status = parsed.status;
     if (parsed.estimateMin !== undefined) data.estimateMin = parsed.estimateMin;
 
-    const task = await prisma.task.update({ where: { id }, data });
+    const task = await prisma.task.update({
+      where: { id },
+      data,
+      include: {
+        comments: {
+          orderBy: { createdAt: 'desc' },
+        },
+      },
+    });
     return NextResponse.json(task);
   } catch (err: any) {
     return NextResponse.json({ message: err.message ?? 'Erro ao atualizar tarefa' }, { status: 400 });

--- a/app/api/tasks/route.ts
+++ b/app/api/tasks/route.ts
@@ -4,7 +4,14 @@ export const dynamic = 'force-dynamic';
 import { z } from 'zod';
 
 export async function GET() {
-  const tasks = await prisma.task.findMany();
+  const tasks = await prisma.task.findMany({
+    include: {
+      comments: {
+        orderBy: { createdAt: 'desc' },
+      },
+    },
+    orderBy: { createdAt: 'desc' },
+  });
   return NextResponse.json(tasks);
 }
 
@@ -59,7 +66,14 @@ export async function POST(req: Request) {
       data.estimateMin = parsed.estimateMin;
     }
 
-    const task = await prisma.task.create({ data });
+    const task = await prisma.task.create({
+      data,
+      include: {
+        comments: {
+          orderBy: { createdAt: 'desc' },
+        },
+      },
+    });
     return NextResponse.json(task);
   } catch (err: any) {
     return NextResponse.json({ message: err.message ?? 'Erro ao criar tarefa' }, { status: 400 });

--- a/components/projects/ProjectListItem.tsx
+++ b/components/projects/ProjectListItem.tsx
@@ -4,6 +4,7 @@ import { Project } from '@/types';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Calendar, Edit, Link2 } from 'lucide-react';
+import { formatDateTime } from '@/lib/utils';
 
 interface ProjectListItemProps {
   project: Project;
@@ -12,6 +13,11 @@ interface ProjectListItemProps {
   plannedDateLabel: string;
   salesforceUrl?: string | null;
   sharepointUrl?: string | null;
+  latestComment?: {
+    message: string;
+    createdAt: string;
+    taskTitle: string;
+  };
 }
 
 export function ProjectListItem({
@@ -21,6 +27,7 @@ export function ProjectListItem({
   plannedDateLabel,
   salesforceUrl,
   sharepointUrl,
+  latestComment,
 }: ProjectListItemProps) {
   const isClockfyLinked = Boolean(project.clockfyProjectId);
   const clockfyStatus = project.syncWithClockfy
@@ -61,6 +68,20 @@ export function ProjectListItem({
           >
             {badgeLabel}
           </Badge>
+          <div className="mt-3 rounded-md border border-gray-800 bg-gray-900/40 p-3">
+            <p className="text-[10px] font-semibold uppercase tracking-wide text-gray-500">Última atualização</p>
+            {latestComment ? (
+              <div className="mt-1 space-y-1">
+                <p className="text-[11px] text-gray-500">{formatDateTime(latestComment.createdAt)}</p>
+                <p className="text-xs text-gray-300">{latestComment.taskTitle}</p>
+                <p className="text-sm text-white whitespace-pre-wrap leading-snug">
+                  {latestComment.message}
+                </p>
+              </div>
+            ) : (
+              <p className="mt-1 text-xs text-gray-500">Nenhum comentário registrado ainda.</p>
+            )}
+          </div>
         </div>
       </div>
 

--- a/components/tasks/TaskCard.tsx
+++ b/components/tasks/TaskCard.tsx
@@ -1,17 +1,18 @@
 'use client';
 
 import { Card } from '@/components/ui/card';
-import { useState } from 'react';
+import { FormEvent, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Task } from '@/types';
 import { useAppStore } from '@/stores/useAppStore';
 import { ProjectBadge } from '@/components/ui/project-badge';
 import { PriorityTag } from '@/components/ui/priority-tag';
-import { formatDuration, formatFriendlyDate } from '@/lib/utils';
+import { formatDateTime, formatDuration, formatFriendlyDate } from '@/lib/utils';
 import { Play, Calendar, Clock, MoreVertical, ExternalLink } from 'lucide-react';
 import { useTimerStore } from '@/stores/useTimerStore';
 import { useRouter } from 'next/navigation';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
+import { Textarea } from '@/components/ui/textarea';
 
 interface TaskCardProps {
   task: Task;
@@ -19,8 +20,10 @@ interface TaskCardProps {
 }
 
 export function TaskCard({ task, onEdit }: TaskCardProps) {
-  const { projects, updateTask, deleteTask } = useAppStore();
+  const { projects, updateTask, deleteTask, addTaskComment } = useAppStore();
   const [isDeleting, setIsDeleting] = useState(false);
+  const [isSubmittingComment, setIsSubmittingComment] = useState(false);
+  const [commentText, setCommentText] = useState('');
   const { startTimer, switchTask, isRunning } = useTimerStore();
   const router = useRouter();
 
@@ -49,6 +52,25 @@ export function TaskCard({ task, onEdit }: TaskCardProps) {
   const hasEstimatedDelivery = Boolean(estimatedDeliveryDate);
   const hasSalesforceLink = Boolean(salesforceLink);
   const hasRepoLink = Boolean(repoLink);
+
+  const comments = task.comments ?? [];
+  const sortedComments = [...comments].sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+  );
+
+  const handleSubmitComment = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmed = commentText.trim();
+    if (!trimmed || isSubmittingComment) return;
+
+    setIsSubmittingComment(true);
+    try {
+      await addTaskComment(task.id, trimmed);
+      setCommentText('');
+    } finally {
+      setIsSubmittingComment(false);
+    }
+  };
 
   return (
     <Card className="p-4 bg-gray-900/50 border-gray-800 hover:bg-gray-900/70 transition-colors">
@@ -169,6 +191,45 @@ export function TaskCard({ task, onEdit }: TaskCardProps) {
             )}
           </div>
         </div>
+      </div>
+
+      <div className="mb-4 space-y-3 rounded-lg border border-gray-800 bg-gray-900/40 p-3">
+        <div className="flex items-center justify-between">
+          <h5 className="text-sm font-semibold text-white">Atualizações</h5>
+          <span className="text-xs text-gray-500">{sortedComments.length} comentários</span>
+        </div>
+
+        <div className="space-y-3 max-h-40 overflow-y-auto pr-1">
+          {sortedComments.length === 0 ? (
+            <p className="text-sm text-gray-500">Nenhum comentário ainda.</p>
+          ) : (
+            sortedComments.map(comment => (
+              <div key={comment.id} className="rounded-md border border-gray-800/80 bg-gray-950/40 p-2">
+                <p className="text-xs text-gray-500">{formatDateTime(comment.createdAt)}</p>
+                <p className="text-sm text-gray-200 whitespace-pre-wrap">{comment.message}</p>
+              </div>
+            ))
+          )}
+        </div>
+
+        <form onSubmit={handleSubmitComment} className="space-y-2">
+          <Textarea
+            value={commentText}
+            onChange={(event) => setCommentText(event.target.value)}
+            placeholder="Adicione uma atualização..."
+            className="min-h-[80px] bg-gray-800 border-gray-700 text-white"
+          />
+          <div className="flex justify-end">
+            <Button
+              type="submit"
+              size="sm"
+              disabled={isSubmittingComment || commentText.trim().length === 0}
+              className="bg-blue-600 hover:bg-blue-700"
+            >
+              {isSubmittingComment ? 'Adicionando...' : 'Adicionar comentário'}
+            </Button>
+          </div>
+        </form>
       </div>
 
       <div className="flex items-center justify-between">

--- a/components/tasks/TaskDialog.tsx
+++ b/components/tasks/TaskDialog.tsx
@@ -9,7 +9,7 @@ import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 import { useAppStore } from '@/stores/useAppStore';
-import { Task } from '@/types';
+import { Task, TaskInput } from '@/types';
 import { useToast } from '@/hooks/use-toast';
 
 interface TaskDialogProps {
@@ -58,7 +58,7 @@ export function TaskDialog({ open, onOpenChange, task, defaultProjectId }: TaskD
             const trimmedTitle = title.trim();
             const trimmedDescription = description.trim();
 
-            const payload: Omit<Task, 'id' | 'createdAt'> = {
+            const payload: TaskInput = {
                 projectId,
                 title: trimmedTitle,
                 priority,
@@ -73,7 +73,7 @@ export function TaskDialog({ open, onOpenChange, task, defaultProjectId }: TaskD
 
 
             if (task) {
-                await updateTask(task.id, payload as Partial<Task>);
+                await updateTask(task.id, payload);
                 toast({ title: 'Tarefa atualizada' });
             } else {
                 await addTask(payload);

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1,5 +1,5 @@
 // src/lib/storage.ts
-import { Project, Task, FocusSession, PomodoroSettings, DailyPlan, ClockfySettings } from '@/types';
+import { Project, Task, TaskComment, TaskInput, FocusSession, PomodoroSettings, DailyPlan, ClockfySettings } from '@/types';
 
 /**
  * ------------------------------------------------------------
@@ -223,8 +223,8 @@ export const storage = {
     return request<Task[]>('/api/tasks');
   },
 
-  async addTask(task: Omit<Task, 'id' | 'createdAt'>): Promise<Task> {
-    const payload: Omit<Task, 'id' | 'createdAt'> & { priority?: Task['priority']; status?: Task['status'] } =
+  async addTask(task: TaskInput): Promise<Task> {
+    const payload: TaskInput & { priority?: Task['priority']; status?: Task['status'] } =
       { priority: 'media', status: 'todo', ...task };
     return request<Task>('/api/tasks', {
       method: 'POST',
@@ -232,7 +232,7 @@ export const storage = {
     });
   },
 
-  async updateTask(id: string, updates: Partial<Task>): Promise<Task> {
+  async updateTask(id: string, updates: Partial<TaskInput>): Promise<Task> {
     return request<Task>(`/api/tasks/${id}`, {
       method: 'PATCH',
       body: updates,
@@ -241,6 +241,13 @@ export const storage = {
 
   async deleteTask(id: string): Promise<void> {
     await request<unknown>(`/api/tasks/${id}`, { method: 'DELETE' });
+  },
+
+  async addTaskComment(taskId: string, message: string): Promise<TaskComment> {
+    return request<TaskComment>(`/api/tasks/${taskId}/comments`, {
+      method: 'POST',
+      body: { message },
+    });
   },
 
   /**

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,6 +1,7 @@
 import { clsx, type ClassValue } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 import { format, startOfDay, endOfDay, isToday, isThisWeek } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
 import { FocusSession, Task, Project } from '@/types';
 import jsPDF from 'jspdf';
 
@@ -24,6 +25,14 @@ export function formatFriendlyDate(value: string | Date): string {
     return '';
   }
   return format(date, 'dd/MM/yyyy');
+}
+
+export function formatDateTime(value: string | Date): string {
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+  return format(date, "dd/MM/yyyy 'às' HH:mm", { locale: ptBR });
 }
 
 export function formatTime(seconds: number): string {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,6 +55,15 @@ model Task {
   estimateMin Int?
   createdAt   DateTime       @default(now())
   sessions    FocusSession[]
+  comments    TaskComment[]
+}
+
+model TaskComment {
+  id        String   @id @default(cuid())
+  task      Task     @relation(fields: [taskId], references: [id], onDelete: Cascade)
+  taskId    String
+  message   String
+  createdAt DateTime @default(now())
 }
 
 model FocusSession {

--- a/types/index.ts
+++ b/types/index.ts
@@ -24,7 +24,25 @@ export interface Task {
   status?: 'todo' | 'doing' | 'done';
   estimateMin?: number;
   createdAt: string;
+  comments?: TaskComment[];
 }
+
+export interface TaskComment {
+  id: string;
+  taskId: string;
+  message: string;
+  createdAt: string;
+}
+
+export type TaskInput = {
+  projectId: string;
+  title: string;
+  description?: string | null;
+  priority?: 'alta' | 'media' | 'baixa';
+  plannedFor?: 'today' | string | null;
+  status?: 'todo' | 'doing' | 'done';
+  estimateMin?: number;
+};
 
 export interface FocusSession {
   id: string;


### PR DESCRIPTION
## Summary
- add persistent task comments and expose a dedicated API endpoint
- update task cards with a timeline and form to record timestamped updates
- surface the latest task comment on related project cards and list entries

## Testing
- yarn lint *(fails: workspace dependencies not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dac75f9b20832b854c65030658e043