### PR TITLE
feat: allow planning for different days and weekly summary

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -80,13 +80,35 @@ export function getTaskCompletionRate(tasks: Task[]): number {
 }
 
 export function getProjectHoursToday(sessions: FocusSession[], projectId: string): number {
-  const today = new Date();
+  return getProjectHoursForDate(sessions, projectId, new Date());
+}
+
+export function getProjectHoursForDate(
+  sessions: FocusSession[],
+  projectId: string,
+  date: Date
+): number {
+  const dayStart = startOfDay(date);
+  const dayEnd = endOfDay(date);
+
   const projectSessions = sessions.filter(session => {
     const sessionDate = new Date(session.start);
-    return isToday(sessionDate) && session.projectId === projectId;
+    return session.projectId === projectId && sessionDate >= dayStart && sessionDate <= dayEnd;
   });
-  
+
   return projectSessions.reduce((total, session) => total + session.durationSec, 0);
+}
+
+export function getTotalWorkSecondsForDate(sessions: FocusSession[], date: Date): number {
+  const dayStart = startOfDay(date);
+  const dayEnd = endOfDay(date);
+
+  const daySessions = sessions.filter(session => {
+    const sessionDate = new Date(session.start);
+    return sessionDate >= dayStart && sessionDate <= dayEnd;
+  });
+
+  return daySessions.reduce((total, session) => total + session.durationSec, 0);
 }
 
 export function getHoursByProject(sessions: FocusSession[], projects: Project[]) {


### PR DESCRIPTION
## Summary
- add date navigation and calendar picker to the daily plan so plans can be viewed and saved for any day
- reuse new date-aware helpers to calculate planned progress for the selected day
- show a weekly planning efficiency table in the reports view using stored plans and sessions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e58c9f2bc0832b876a620807a40d4e