### PR TITLE
Persist today filter on tasks board

### DIFF
--- a/app/(protected)/tasks/page.tsx
+++ b/app/(protected)/tasks/page.tsx
@@ -71,13 +71,14 @@ function DroppableColumn({ id, title, colorClass, children }: { id: ColumnId; ti
 }
 
 export default function TasksPage() {
-  const { tasks, projects, updateTask } = useAppStore();
+  const { tasks, projects, updateTask, tasksFilters, setTasksFilters } = useAppStore();
   const [selectedProjectId, setSelectedProjectId] = useState<string>('all');
-  const [showOnlyToday, setShowOnlyToday] = useState(false);
   const [editingTask, setEditingTask] = useState<Task | undefined>();
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [focusId, setFocusId] = useState<string | null>(null);
+
+  const showOnlyToday = tasksFilters.showOnlyToday;
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -188,7 +189,11 @@ export default function TasksPage() {
           </div>
 
           <div className="flex items-center space-x-2">
-            <Switch id="today-only" checked={showOnlyToday} onCheckedChange={setShowOnlyToday} />
+            <Switch
+              id="today-only"
+              checked={showOnlyToday}
+              onCheckedChange={(value) => setTasksFilters({ showOnlyToday: value })}
+            />
             <Label htmlFor="today-only" className="text-gray-300">Somente de hoje</Label>
           </div>
         </div>

--- a/stores/useAppStore.ts
+++ b/stores/useAppStore.ts
@@ -4,6 +4,10 @@ import { create } from 'zustand';
 import { Project, Task, TaskInput, FocusSession, PomodoroSettings, DailyPlan, ClockfySettings } from '@/types';
 import { storage } from '@/lib/storage';
 
+interface TasksFilters {
+  showOnlyToday: boolean;
+}
+
 interface AppStore {
   projects: Project[];
   tasks: Task[];
@@ -12,6 +16,7 @@ interface AppStore {
   clockfySettings: ClockfySettings;
   dailyPlans: DailyPlan[];
   theme: 'dark' | 'light' | 'system';
+  tasksFilters: TasksFilters;
 
   initializeData: () => Promise<void>;
 
@@ -41,6 +46,8 @@ interface AppStore {
   exportData: () => string;
   importData: (jsonData: string) => boolean;
   clearAllData: () => void;
+
+  setTasksFilters: (updates: Partial<TasksFilters>) => void;
 }
 
 export const useAppStore = create<AppStore>((set, get) => ({
@@ -62,6 +69,9 @@ export const useAppStore = create<AppStore>((set, get) => ({
   },
   dailyPlans: [],
   theme: 'dark',
+  tasksFilters: {
+    showOnlyToday: false,
+  },
 
   initializeData: async () => {
     const [projects, tasks, sessions, pomodoroSettings, clockfySettings, dailyPlans] = await Promise.all([
@@ -257,6 +267,18 @@ export const useAppStore = create<AppStore>((set, get) => ({
       tasks: [],
       sessions: [],
       dailyPlans: [],
+      tasksFilters: {
+        showOnlyToday: false,
+      },
     });
+  },
+
+  setTasksFilters: (updates) => {
+    set((state) => ({
+      tasksFilters: {
+        ...state.tasksFilters,
+        ...updates,
+      },
+    }));
   },
 }));


### PR DESCRIPTION
## Summary
- add a tasksFilters slice to the app store so UI filters can persist between screens
- consume the shared showOnlyToday flag on the tasks board switch to keep the "Somente de hoje" filter active after navigation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e90340c314832b8eff32c2e3ee8511