### PR TITLE
Restrict archived projects and add recovery tools

### DIFF
--- a/app/(protected)/settings/page.tsx
+++ b/app/(protected)/settings/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -24,6 +24,7 @@ export default function SettingsPage() {
     projects,
   } = useAppStore();
   const { toast } = useToast();
+  const activeProjects = useMemo(() => projects.filter(project => project.active), [projects]);
 
   const [settings, setSettings] = useState(pomodoroSettings);
   const [clockfyForm, setClockfyForm] = useState({
@@ -328,12 +329,12 @@ export default function SettingsPage() {
             )}
 
             <div className="space-y-2">
-              {projects.length === 0 ? (
+              {activeProjects.length === 0 ? (
                 <p className="text-sm text-gray-400">
                   Nenhum projeto cadastrado ainda.
                 </p>
               ) : (
-                projects.map((project) => {
+                activeProjects.map((project) => {
                   const clockfyStatus = project.syncWithClockfy
                     ? project.clockfyProjectId
                       ? 'synced'

--- a/app/(protected)/tasks/page.tsx
+++ b/app/(protected)/tasks/page.tsx
@@ -97,7 +97,10 @@ export default function TasksPage() {
   }, []);
 
   const searchTerm = searchQuery.trim().toLowerCase();
+  const activeProjectIds = useMemo(() => new Set(projects.filter(project => project.active).map(project => project.id)), [projects]);
+
   const filteredTasks = tasks.filter(task => {
+    if (!activeProjectIds.has(task.projectId)) return false;
     if (selectedProjectId !== 'all' && task.projectId !== selectedProjectId) return false;
     if (showOnlyToday) return getTodayTasks([task]).length > 0;
     if (!searchTerm) return true;

--- a/components/dashboard/Charts.tsx
+++ b/components/dashboard/Charts.tsx
@@ -7,8 +7,9 @@ import { getHoursByProject, getDailyHours } from '@/lib/utils';
 
 export function Charts() {
   const { sessions, projects } = useAppStore();
-  
-  const projectData = getHoursByProject(sessions, projects).filter(p => p.hours > 0);
+  const activeProjects = projects.filter(project => project.active);
+
+  const projectData = getHoursByProject(sessions, activeProjects).filter(p => p.hours > 0);
   const dailyData = getDailyHours(sessions, 7);
 
   return (

--- a/components/layout/TopNav.tsx
+++ b/components/layout/TopNav.tsx
@@ -39,7 +39,10 @@ export function TopNav() {
   } = useTimerStore();
 
   const { projects, tasks } = useAppStore();
-  const selectedProject = projects.find(p => p.id === selectedProjectId);
+  const activeProjects = useMemo(() => projects.filter(project => project.active), [projects]);
+  const selectedProject = selectedProjectId
+    ? activeProjects.find(project => project.id === selectedProjectId)
+    : undefined;
 
   const handleOpenMiniTimer = () => {
     const features = 'width=360,height=260,menubar=no,toolbar=no,location=no,status=no';
@@ -72,7 +75,7 @@ export function TopNav() {
   }, [projects]);
 
   const searchTerm = searchQuery.trim().toLowerCase();
-  const filteredProjects = projects.filter((project) => {
+  const filteredProjects = activeProjects.filter((project) => {
     if (!searchTerm) {
       return true;
     }
@@ -83,10 +86,14 @@ export function TopNav() {
   });
 
   const filteredTasks = tasks.filter((task) => {
+    const project = projectMap[task.projectId];
+    if (!project?.active) {
+      return false;
+    }
     if (!searchTerm) {
       return true;
     }
-    const projectName = (projectMap[task.projectId]?.name ?? '').toLowerCase();
+    const projectName = (project?.name ?? '').toLowerCase();
     const description = (task.description ?? '').toLowerCase();
     return (
       task.title.toLowerCase().includes(searchTerm) ||

--- a/components/projects/ProjectCard.tsx
+++ b/components/projects/ProjectCard.tsx
@@ -6,7 +6,7 @@ import { Badge } from '@/components/ui/badge';
 import { Project } from '@/types';
 import { useAppStore } from '@/stores/useAppStore';
 import { formatDuration, formatFriendlyDate, getProjectHoursToday } from '@/lib/utils';
-import { MoreVertical, Edit, Archive, Play, MessageSquare } from 'lucide-react';
+import { MoreVertical, Edit, Archive, ArchiveRestore, Play, MessageSquare } from 'lucide-react';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import { useRouter } from 'next/navigation';
 
@@ -18,6 +18,8 @@ interface ProjectCardProps {
 export function ProjectCard({ project, onEdit }: ProjectCardProps) {
   const { sessions, tasks, updateProject } = useAppStore();
   const router = useRouter();
+
+  const isArchived = !project.active;
 
   const todayHours = getProjectHoursToday(sessions, project.id);
   const weekHours = sessions
@@ -42,8 +44,8 @@ export function ProjectCard({ project, onEdit }: ProjectCardProps) {
       : 'pending'
     : 'disabled';
 
-  const handleArchive = () => {
-    updateProject(project.id, { active: false });
+  const handleToggleArchive = () => {
+    updateProject(project.id, { active: !project.active });
   };
 
   return (
@@ -55,7 +57,14 @@ export function ProjectCard({ project, onEdit }: ProjectCardProps) {
             style={{ backgroundColor: project.color }} 
           />
           <div>
-            <h3 className="font-semibold text-white">{project.name}</h3>
+            <div className="flex items-center gap-2">
+              <h3 className="font-semibold text-white">{project.name}</h3>
+              {isArchived && (
+                <Badge variant="outline" className="text-xs text-amber-300 border-amber-400/60 bg-amber-500/10">
+                  Arquivado
+                </Badge>
+              )}
+            </div>
             <div className="flex items-center gap-2 mt-1">
               {project.client && (
                 <p className="text-sm text-gray-400">{project.client}</p>
@@ -91,9 +100,16 @@ export function ProjectCard({ project, onEdit }: ProjectCardProps) {
               <Edit className="h-4 w-4 mr-2" />
               Editar
             </DropdownMenuItem>
-            <DropdownMenuItem onClick={handleArchive} className="cursor-pointer text-red-400">
-              <Archive className="h-4 w-4 mr-2" />
-              Arquivar
+            <DropdownMenuItem
+              onClick={handleToggleArchive}
+              className={`cursor-pointer ${isArchived ? 'text-emerald-300' : 'text-red-400'}`}
+            >
+              {isArchived ? (
+                <ArchiveRestore className="h-4 w-4 mr-2" />
+              ) : (
+                <Archive className="h-4 w-4 mr-2" />
+              )}
+              {isArchived ? 'Desarquivar' : 'Arquivar'}
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
@@ -166,7 +182,11 @@ export function ProjectCard({ project, onEdit }: ProjectCardProps) {
       )}
 
       <div className="mt-4 flex flex-col gap-2 sm:flex-row">
-        <Button className="flex-1 bg-blue-600 hover:bg-blue-700" onClick={() => router.push('/focus')}>
+        <Button
+          className="flex-1 bg-blue-600 hover:bg-blue-700"
+          onClick={() => router.push('/focus')}
+          disabled={isArchived}
+        >
           <Play className="h-4 w-4 mr-2" />
           Iniciar Foco
         </Button>

--- a/components/projects/ProjectDialog.tsx
+++ b/components/projects/ProjectDialog.tsx
@@ -81,12 +81,14 @@ export function ProjectDialog({ open, onOpenChange, project }: ProjectDialogProp
       const trimmedSalesforceUrl = salesforceOppUrl.trim();
       const trimmedSharepointUrl = sharepointRepoUrl.trim();
 
+      const isEditing = Boolean(project);
+
       const projectData = {
         name: name.trim(),
         client: client.trim() || undefined,
         color,
         hourlyRate: hourlyRate ? parseFloat(hourlyRate) : undefined,
-        active: true,
+        active: isEditing && project ? project.active : true,
         syncWithClockfy,
         salesforceOppUrl: trimmedSalesforceUrl ? trimmedSalesforceUrl : null,
         sharepointRepoUrl: trimmedSharepointUrl ? trimmedSharepointUrl : null,

--- a/components/projects/ProjectListItem.tsx
+++ b/components/projects/ProjectListItem.tsx
@@ -3,12 +3,13 @@
 import { Project } from '@/types';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { Calendar, Edit, Link2, MessageSquare } from 'lucide-react';
+import { Calendar, Edit, Link2, MessageSquare, Archive, ArchiveRestore } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 
 interface ProjectListItemProps {
   project: Project;
   onEdit: (project: Project) => void;
+  onToggleActive: (project: Project) => void;
   newUrlsLabel: string;
   plannedDateLabel: string;
   salesforceUrl?: string | null;
@@ -19,6 +20,7 @@ interface ProjectListItemProps {
 export function ProjectListItem({
   project,
   onEdit,
+  onToggleActive,
   newUrlsLabel,
   plannedDateLabel,
   salesforceUrl,
@@ -32,6 +34,8 @@ export function ProjectListItem({
       ? 'linked'
       : 'pending'
     : 'disabled';
+
+  const isArchived = !project.active;
 
   const badgeClassName =
     clockfyStatus === 'linked'
@@ -58,7 +62,14 @@ export function ProjectListItem({
           style={{ backgroundColor: project.color }}
         />
         <div>
-          <p className="font-medium text-white">{project.name}</p>
+          <div className="flex items-center gap-2">
+            <p className="font-medium text-white">{project.name}</p>
+            {isArchived && (
+              <Badge variant="outline" className="text-[10px] text-amber-300 border-amber-400/60 bg-amber-500/10">
+                Arquivado
+              </Badge>
+            )}
+          </div>
           <Badge
             variant={clockfyStatus === 'linked' ? 'secondary' : 'outline'}
             className={`mt-2 h-5 px-2 text-xs ${badgeClassName}`}
@@ -132,7 +143,7 @@ export function ProjectListItem({
         </span>
       </div>
 
-      <div className="flex justify-start md:justify-end">
+      <div className="flex justify-start md:justify-end gap-2">
         <Button
           variant="outline"
           size="sm"
@@ -141,6 +152,19 @@ export function ProjectListItem({
         >
           <Edit className="mr-2 h-4 w-4" />
           Editar
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => onToggleActive(project)}
+          className={`border-gray-700 hover:bg-gray-800 ${isArchived ? 'text-emerald-300' : 'text-red-300'}`}
+        >
+          {isArchived ? (
+            <ArchiveRestore className="mr-2 h-4 w-4" />
+          ) : (
+            <Archive className="mr-2 h-4 w-4" />
+          )}
+          {isArchived ? 'Desarquivar' : 'Arquivar'}
         </Button>
       </div>
     </div>

--- a/components/sessions/ManualSessionDialog.tsx
+++ b/components/sessions/ManualSessionDialog.tsx
@@ -24,6 +24,7 @@ export function ManualSessionDialog({ open, onOpenChange }: ManualSessionDialogP
   const [endTime, setEndTime] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
 
+  const activeProjects = projects.filter(project => project.active);
   const projectTasks = projectId ? tasks.filter(t => t.projectId === projectId) : [];
 
   const handleSave = async () => {
@@ -69,7 +70,7 @@ export function ManualSessionDialog({ open, onOpenChange }: ManualSessionDialogP
                 <SelectValue placeholder="Selecione" />
               </SelectTrigger>
               <SelectContent className="bg-gray-800 border-gray-700">
-                {projects.map(p => (
+                {activeProjects.map(p => (
                   <SelectItem key={p.id} value={p.id}>{p.name}</SelectItem>
                 ))}
               </SelectContent>


### PR DESCRIPTION
## Summary
- hide archived projects and their tasks from global search, task kanban and manual session forms
- add archived/active filter and archive restore actions to the projects page UI while preserving archived state on edit
- ensure analytics, dashboards and settings reports only consider active projects

## Testing
- `yarn lint` *(fails: workspace package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_690c9039b84c832b8c0327507d8222a3