### PR TITLE
Add optional initial task creation when creating projects

### DIFF
--- a/stores/useAppStore.ts
+++ b/stores/useAppStore.ts
@@ -20,7 +20,7 @@ interface AppStore {
 
   initializeData: () => Promise<void>;
 
-  addProject: (project: Omit<Project, 'id' | 'createdAt'>) => Promise<void>;
+  addProject: (project: Omit<Project, 'id' | 'createdAt'>) => Promise<Project>;
   updateProject: (id: string, updates: Partial<Project>) => Promise<void>;
   deleteProject: (id: string) => Promise<void>;
 
@@ -101,6 +101,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
   addProject: async (projectData) => {
     const project = await storage.addProject(projectData);
     set((state) => ({ projects: [...state.projects, project] }));
+    return project;
   },
   updateProject: async (id, updates) => {
     const project = await storage.updateProject(id, updates);


### PR DESCRIPTION
### Motivation

- Provide an option in the new project dialog to create an initial task automatically so users can bootstrap a project with a default work item.

### Description

- Added a `Criar tarefa inicial` switch and a `Nome da tarefa` input to `components/projects/ProjectDialog.tsx` with a default value `Análise e elaboração do escopo` when creating a new project.
- When creating a new project and the switch is enabled, the dialog now creates a task via `addTask` after the project is created.
- Updated `stores/useAppStore.ts` so `addProject` returns the created `Project` instance, enabling immediate creation of a linked task.
- The existing manual task creation and project editing flows remain unchanged.

### Testing

- Attempted to run `npm run dev` but it failed in the environment because `next` was not available before dependencies were installed.
- Ran `npm install` which failed during `prisma generate` due to a Prisma engine checksum download error (`403 Forbidden`), so the dev server and integration checks could not be started.
- No automated unit or integration tests were executed as dependency setup failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a9b39cf8c832bb48d49a36698e7d6)